### PR TITLE
Fix cache bug

### DIFF
--- a/robospice-cache/src/com/octo/android/robospice/persistence/file/InFileObjectPersister.java
+++ b/robospice-cache/src/com/octo/android/robospice/persistence/file/InFileObjectPersister.java
@@ -34,8 +34,8 @@ public abstract class InFileObjectPersister< T > extends ObjectPersister< T > {
         final String prefix = getCachePrefix();
         String[] cacheFileNameList = getCacheFolder().list( new FilenameFilter() {
             @Override
-            public boolean accept( File arg0, String arg1 ) {
-                return arg0.getName().startsWith( prefix );
+            public boolean accept( File dir, String filename ) {
+                return filename.startsWith( prefix );
             }
         } );
         List< Object > result = new ArrayList< Object >();


### PR DESCRIPTION
When trying to get all data from cache, nothing is returned because it checks the prefix against the name of the cache folder, not the file name itself.
