### PR TITLE
Removed canHandleClass method

### DIFF
--- a/robospice-cache/src/com/octo/android/robospice/persistence/json/gson/GsonObjectPersister.java
+++ b/robospice-cache/src/com/octo/android/robospice/persistence/json/gson/GsonObjectPersister.java
@@ -139,11 +139,6 @@ public final class GsonObjectPersister<T> extends InFileObjectPersister<T> {
 		}
 	}
 
-	@Override
-	public boolean canHandleClass(Class<?> clazz) {
-		return true;
-	}
-
 	/** for testing purpose only. Overriding allows to regive package level visibility. */
 	@Override
 	protected void awaitForSaveAsyncTermination(long time, TimeUnit timeUnit) throws InterruptedException {


### PR DESCRIPTION
public boolean canHandleClass(Class<?> clazz) {...} returned always true but that's not right because we need the clazz.equals(this.clazz) check to avoid class cast exceptions if we get the data from the cache.
