### PR TITLE
Fix RequestProcessor.removeSpiceServiceListener to actually remove listener rather than adding it again

### DIFF
--- a/robospice-core-parent/robospice/src/main/java/com/octo/android/robospice/request/RequestProcessor.java
+++ b/robospice-core-parent/robospice/src/main/java/com/octo/android/robospice/request/RequestProcessor.java
@@ -560,7 +560,7 @@ public class RequestProcessor {
     }
 
     public void removeSpiceServiceListener(final SpiceServiceServiceListener spiceServiceServiceListener) {
-        this.spiceServiceListenerSet.add(spiceServiceServiceListener);
+        this.spiceServiceListenerSet.remove(spiceServiceServiceListener);
     }
 
     protected void notifyOfRequestProcessed(final CachedSpiceRequest<?> request) {


### PR DESCRIPTION
Fixes issue #131
