### PR TITLE
Fix DefaultRetryPolicy getDelayBeforeRetry return value plus add test case.

### DIFF
--- a/robospice-core-parent/robospice-core-test/src/main/java/com/octo/android/robospice/request/RequestProcessorTest.java
+++ b/robospice-core-parent/robospice-core-test/src/main/java/com/octo/android/robospice/request/RequestProcessorTest.java
@@ -887,6 +887,27 @@ public class RequestProcessorTest extends InstrumentationTestCase {
         assertTrue(mockRequestListener.getReceivedException() instanceof NoNetworkException);
     }
 
+    public void testDefaultRetryPolicy_implements_retry_countdown_and_exponential_backoff() throws Exception {
+        // define local values since class constant values didn't reveal incremental backoff
+        final long localDelayBeforeRetry = 200;
+        final float localRetryBackoffMultiplier = 5.0f;
+        final int localRetryCount = 3;
+
+        // given
+        DefaultRetryPolicy retryPolicy = new DefaultRetryPolicy(localRetryCount, localDelayBeforeRetry, localRetryBackoffMultiplier);
+
+        assertEquals(localRetryCount, retryPolicy.getRetryCount());
+        assertEquals(localDelayBeforeRetry, retryPolicy.getDelayBeforeRetry());
+
+        // when
+        SpiceException e = null;
+        retryPolicy.retry(e);
+
+        // then
+        assertEquals(localRetryCount - 1, retryPolicy.getRetryCount());
+        assertEquals(((long) (localDelayBeforeRetry * localRetryBackoffMultiplier)), retryPolicy.getDelayBeforeRetry());
+    }
+
     // ============================================================================================
     // NETWORK STATE CHECKER DEPENDENCY
     // ============================================================================================

--- a/robospice-core-parent/robospice/src/main/java/com/octo/android/robospice/retry/DefaultRetryPolicy.java
+++ b/robospice-core-parent/robospice/src/main/java/com/octo/android/robospice/retry/DefaultRetryPolicy.java
@@ -6,7 +6,7 @@ import com.octo.android.robospice.persistence.exception.SpiceException;
  * Default {@link RetryPolicy} implementation. Proposes an exponential back off
  * algorithm. When {@link #getRetryCount()} returns 0, the request is not
  * retried anymore and will fail. Between each retry attempt, the request
- * processor will sleel for {@link #getDelayBeforeRetry()} milliseconds.
+ * processor will sleep for {@link #getDelayBeforeRetry()} milliseconds.
  * @author SNI
  */
 public class DefaultRetryPolicy implements RetryPolicy {
@@ -65,7 +65,7 @@ public class DefaultRetryPolicy implements RetryPolicy {
 
     @Override
     public long getDelayBeforeRetry() {
-        return 0;
+        return delayBeforeRetry;
     }
 
 }


### PR DESCRIPTION
DefaultRetryPolicy.getDelayBeforeRetry was returning a fixed value of zero milliseconds delay. Now returns value computed by exponential backoff policy.
