### PR TITLE
Remove code duplication from RetrofitObjectPersister.loadDataFromCache and instead use readCacheDataFromFile.

### DIFF
--- a/extensions/robospice-retrofit-parent/robospice-retrofit-test/src/main/java/com/octo/android/robospice/retrofit/test/RetrofitSpiceTestService.java
+++ b/extensions/robospice-retrofit-parent/robospice-retrofit-test/src/main/java/com/octo/android/robospice/retrofit/test/RetrofitSpiceTestService.java
@@ -8,7 +8,7 @@ public class RetrofitSpiceTestService extends RetrofitGsonSpiceService {
 
     @Override
     protected String getServerUrl() {
-        return "";
+        return "non-blank.random.server";
     }
 
     @Override


### PR DESCRIPTION
Remove code duplication. RetrofitObjectPersister's base class, InFileObjectPersister, already handles cache hit checking.  Move relevant code to RetrofitObjectPersister.readCacheDataFromFile, which is called on cache hit.  The only change of behavior is that the retrofit reimplementation logged cache misses.

Also fixed RetrofitSpiceTestService which was failing because the server url was empty.
