### PR TITLE
Remove RequestCancellationListener after requests

### DIFF
--- a/robospice-core-parent/robospice/src/main/java/com/octo/android/robospice/request/RequestProcessor.java
+++ b/robospice-core-parent/robospice/src/main/java/com/octo/android/robospice/request/RequestProcessor.java
@@ -315,6 +315,9 @@ public class RequestProcessor {
                 } catch (final Throwable t) {
                     Ln.d(t, "An unexpected error occured when processsing request %s", request.toString());
                 }
+                finally {
+                    request.setRequestCancellationListener(null);
+                }
             }
 
             @Override


### PR DESCRIPTION
Caused memory leak in 1.4.4 for me. 
https://groups.google.com/d/msg/robospice/8Qfs6zgByFo/xEK3TJ6xhmUJ
