### PR TITLE
Fix RoboSpiceContentProvider to declare single item URI type as ITEM rather than DIRECTORY.

### DIFF
--- a/extensions/robospice-ormlite-content-provider-parent/robospice-ormlite-content-provider/src/main/java/com/octo/android/robospice/persistence/ormlite/RoboSpiceContentProvider.java
+++ b/extensions/robospice-ormlite-content-provider-parent/robospice-ormlite-content-provider/src/main/java/com/octo/android/robospice/persistence/ormlite/RoboSpiceContentProvider.java
@@ -33,7 +33,7 @@ public abstract class RoboSpiceContentProvider extends OrmLiteSimpleContentProvi
                 int contentUriPatternMany = ContractHelper.getContentUriPatternMany(contractClazz);
                 int contentUriPatternOne = ContractHelper.getContentUriPatternOne(contractClazz);
                 controller.add(clazz, SubType.DIRECTORY, "", contentUriPatternMany);
-                controller.add(clazz, SubType.DIRECTORY, "#", contentUriPatternOne);
+                controller.add(clazz, SubType.ITEM, "#", contentUriPatternOne);
             } catch (Exception e) {
                 Ln.e(e);
             }


### PR DESCRIPTION
Correct URI type for item URI. The Ormlite class uses the type to determine whether the database query filters for the supplied item id.
