### PR TITLE
Added support for notifications customisable per request and managed in the worker thread

### DIFF
--- a/robospice-core-parent/robospice/src/main/java/com/octo/android/robospice/SpiceService.java
+++ b/robospice-core-parent/robospice/src/main/java/com/octo/android/robospice/SpiceService.java
@@ -134,6 +134,15 @@ public abstract class SpiceService extends Service {
      * @return a {@link RequestProcessor} that will be used to process requests.
      */
     protected RequestProcessor createRequestProcessor(ExecutorService executorService, NetworkStateChecker networkStateChecker) {
+        return createRequestProcessor(executorService, networkStateChecker, cacheManager, requestProcessorListener);
+    }
+
+    protected RequestProcessor createRequestProcessor(
+            ExecutorService executorService,
+            NetworkStateChecker networkStateChecker,
+            CacheManager cacheManager,
+            RequestProcessorListener requestProcessorListener) {
+
         return new RequestProcessor(getApplicationContext(), cacheManager, executorService, requestProcessorListener, networkStateChecker);
     }
 

--- a/robospice-core-parent/robospice/src/main/java/com/octo/android/robospice/notification/NotificationFactory.java
+++ b/robospice-core-parent/robospice/src/main/java/com/octo/android/robospice/notification/NotificationFactory.java
@@ -1,0 +1,19 @@
+package com.octo.android.robospice.notification;
+
+import android.app.Notification;
+import android.content.Context;
+
+import com.octo.android.robospice.persistence.exception.SpiceException;
+import com.octo.android.robospice.request.listener.RequestProgress;
+
+public interface NotificationFactory<T> {
+
+    Notification createNotificationForSuccess(Context context, T result);
+
+    Notification createNotificationForFailure(Context context, SpiceException e);
+
+    Notification createNotificationForCancellation(Context context);
+
+    Notification createNotificationForProgressUpdate(Context context,
+            RequestProgress progress);
+}

--- a/robospice-core-parent/robospice/src/main/java/com/octo/android/robospice/notification/NotificationRequestProcessor.java
+++ b/robospice-core-parent/robospice/src/main/java/com/octo/android/robospice/notification/NotificationRequestProcessor.java
@@ -1,0 +1,119 @@
+package com.octo.android.robospice.notification;
+
+import java.util.Set;
+import java.util.concurrent.ExecutorService;
+
+import android.app.Notification;
+import android.app.NotificationManager;
+import android.content.Context;
+
+import com.octo.android.robospice.networkstate.NetworkStateChecker;
+import com.octo.android.robospice.persistence.CacheManager;
+import com.octo.android.robospice.persistence.exception.SpiceException;
+import com.octo.android.robospice.request.CachedSpiceRequest;
+import com.octo.android.robospice.request.RequestProcessor;
+import com.octo.android.robospice.request.RequestProcessorListener;
+import com.octo.android.robospice.request.listener.RequestListener;
+import com.octo.android.robospice.request.listener.RequestProgress;
+import com.octo.android.robospice.request.listener.RequestStatus;
+
+public class NotificationRequestProcessor extends RequestProcessor {
+
+    private NotificationManager nManager;
+    private Context context;
+
+    public NotificationRequestProcessor(Context context,
+            ExecutorService executorService,
+            NetworkStateChecker networkStateChecker, CacheManager cacheManager,
+            RequestProcessorListener requestProcessorListener) {
+
+        super(context, cacheManager, executorService, requestProcessorListener,
+                networkStateChecker);
+
+        this.context = context;
+
+        nManager = (NotificationManager) context
+                .getSystemService(Context.NOTIFICATION_SERVICE);
+    }
+
+    @Override
+    protected <T> void notifyListenersOfRequestFailure(
+            CachedSpiceRequest<T> request, SpiceException e) {
+
+        if (request.getSpiceRequest() instanceof RequestNotification) {
+            RequestNotification requestNotification = (RequestNotification) request
+                    .getSpiceRequest();
+
+            Notification notification = requestNotification
+                    .getNotificationFactory().createNotificationForFailure(
+                            context, e);
+
+            nManager.notify(requestNotification.getNotificationId(),
+                    notification);
+        }
+
+        super.notifyListenersOfRequestFailure(request, e);
+    }
+
+    @Override
+    protected <T> void notifyListenersOfRequestSuccess(
+            CachedSpiceRequest<T> request, T result) {
+
+        if (request.getSpiceRequest() instanceof RequestNotification) {
+            RequestNotification requestNotification = (RequestNotification) request
+                    .getSpiceRequest();
+
+            Notification notification = requestNotification
+                    .getNotificationFactory().createNotificationForSuccess(
+                            context, result);
+
+            nManager.notify(requestNotification.getNotificationId(),
+                    notification);
+        }
+
+        super.notifyListenersOfRequestSuccess(request, result);
+    }
+
+    @Override
+    protected void notifyListenersOfRequestCancellation(
+            CachedSpiceRequest<?> request, Set<RequestListener<?>> listeners) {
+
+        if (request.getSpiceRequest() instanceof RequestNotification) {
+            RequestNotification requestNotification = (RequestNotification) request
+                    .getSpiceRequest();
+
+            Notification notification = requestNotification
+                    .getNotificationFactory()
+                    .createNotificationForCancellation(context);
+
+            nManager.notify(requestNotification.getNotificationId(),
+                    notification);
+        }
+
+        super.notifyListenersOfRequestCancellation(request, listeners);
+    }
+
+    @Override
+    protected <T> void notifyListenersOfRequestProgress(
+            CachedSpiceRequest<?> request, Set<RequestListener<?>> listeners,
+            RequestProgress progress) {
+
+        // We don't want a progress noitification AFTER receiving a
+        // Success/Failure/Cancellation
+        if (request.getSpiceRequest() instanceof RequestNotification
+                && progress.getStatus() != RequestStatus.COMPLETE) {
+
+            RequestNotification requestNotification = (RequestNotification) request
+                    .getSpiceRequest();
+
+            Notification notification = requestNotification
+                    .getNotificationFactory()
+                    .createNotificationForProgressUpdate(context, progress);
+
+            nManager.notify(requestNotification.getNotificationId(),
+                    notification);
+        }
+
+        super.notifyListenersOfRequestProgress(request, listeners, progress);
+    }
+}

--- a/robospice-core-parent/robospice/src/main/java/com/octo/android/robospice/notification/RequestNotification.java
+++ b/robospice-core-parent/robospice/src/main/java/com/octo/android/robospice/notification/RequestNotification.java
@@ -1,0 +1,8 @@
+package com.octo.android.robospice.notification;
+
+public interface RequestNotification<T> {
+
+    int getNotificationId();
+
+    NotificationFactory<T> getNotificationFactory();
+}

--- a/robospice-core-parent/robospice/src/main/java/com/octo/android/robospice/notification/SpiceRequestNotificationService.java
+++ b/robospice-core-parent/robospice/src/main/java/com/octo/android/robospice/notification/SpiceRequestNotificationService.java
@@ -1,0 +1,23 @@
+package com.octo.android.robospice.notification;
+
+import java.util.concurrent.ExecutorService;
+
+import com.octo.android.robospice.SpiceService;
+import com.octo.android.robospice.networkstate.NetworkStateChecker;
+import com.octo.android.robospice.persistence.CacheManager;
+import com.octo.android.robospice.request.RequestProcessor;
+import com.octo.android.robospice.request.RequestProcessorListener;
+
+public abstract class SpiceRequestNotificationService extends SpiceService {
+
+    @Override
+    protected RequestProcessor createRequestProcessor(
+            ExecutorService executorService,
+            NetworkStateChecker networkStateChecker, CacheManager cacheManager,
+            RequestProcessorListener requestProcessorListener) {
+
+        return new NotificationRequestProcessor(getApplicationContext(),
+                executorService, networkStateChecker, cacheManager,
+                requestProcessorListener);
+    }
+}

--- a/robospice-core-parent/robospice/src/main/java/com/octo/android/robospice/request/RequestProcessor.java
+++ b/robospice-core-parent/robospice/src/main/java/com/octo/android/robospice/request/RequestProcessor.java
@@ -352,11 +352,11 @@ public class RequestProcessor {
         handlerResponse.postAtTime(r, token, SystemClock.uptimeMillis());
     }
 
-    private <T> void notifyListenersOfRequestProgress(final CachedSpiceRequest<?> request, final Set<RequestListener<?>> listeners, final RequestStatus status) {
+    protected <T> void notifyListenersOfRequestProgress(final CachedSpiceRequest<?> request, final Set<RequestListener<?>> listeners, final RequestStatus status) {
         notifyListenersOfRequestProgress(request, listeners, new RequestProgress(status));
     }
 
-    private <T> void notifyListenersOfRequestProgress(final CachedSpiceRequest<?> request, final Set<RequestListener<?>> listeners, final RequestProgress progress) {
+    protected <T> void notifyListenersOfRequestProgress(final CachedSpiceRequest<?> request, final Set<RequestListener<?>> listeners, final RequestProgress progress) {
         Ln.d("Sending progress %s", progress.getStatus());
         post(new ProgressRunnable(listeners, progress), request.getRequestCacheKey());
         checkAllRequestComplete();
@@ -375,7 +375,7 @@ public class RequestProcessor {
     }
 
     @SuppressWarnings({ "rawtypes", "unchecked" })
-    private <T> void notifyListenersOfRequestSuccess(final CachedSpiceRequest<T> request, final T result) {
+    protected <T> void notifyListenersOfRequestSuccess(final CachedSpiceRequest<T> request, final T result) {
         final Set<RequestListener<?>> listeners = mapRequestToRequestListener.get(request);
         notifyListenersOfRequestProgress(request, listeners, RequestStatus.COMPLETE);
         post(new ResultRunnable(listeners, result), request.getRequestCacheKey());
@@ -383,7 +383,7 @@ public class RequestProcessor {
     }
 
     @SuppressWarnings({ "rawtypes", "unchecked" })
-    private <T> void notifyListenersOfRequestFailure(final CachedSpiceRequest<T> request, final SpiceException e) {
+    protected <T> void notifyListenersOfRequestFailure(final CachedSpiceRequest<T> request, final SpiceException e) {
         final Set<RequestListener<?>> listeners = mapRequestToRequestListener.get(request);
         notifyListenersOfRequestProgress(request, listeners, RequestStatus.COMPLETE);
         post(new ResultRunnable(listeners, e), request.getRequestCacheKey());
@@ -391,7 +391,7 @@ public class RequestProcessor {
     }
 
     @SuppressWarnings({ "rawtypes", "unchecked" })
-    private void notifyListenersOfRequestCancellation(final CachedSpiceRequest<?> request, final Set<RequestListener<?>> listeners) {
+    protected void notifyListenersOfRequestCancellation(final CachedSpiceRequest<?> request, final Set<RequestListener<?>> listeners) {
         Ln.d("Not calling network request : " + request + " as it is cancelled. ");
         notifyListenersOfRequestProgress(request, listeners, RequestStatus.COMPLETE);
         post(new ResultRunnable(listeners, new RequestCancelledException("Request has been cancelled explicitely.")), request.getRequestCacheKey());


### PR DESCRIPTION
If this code should be incorporated into the main SpiceService then I'll do that. Otherwise you just need to override createRequestProcessor() and return the NotificationRequestProcessor object.
