### PR TITLE
Memory leak fix

### DIFF
--- a/robospice-core-parent/robospice/src/main/java/com/octo/android/robospice/request/RequestProcessor.java
+++ b/robospice-core-parent/robospice/src/main/java/com/octo/android/robospice/request/RequestProcessor.java
@@ -125,7 +125,7 @@ public class RequestProcessor {
             requestProgressManager.notifyListenersOfRequestCancellation(request, listRequestListener);
             return;
         } else if (!request.isProcessable()) {
-            requestProgressManager.notifyOfRequestProcessed(request);
+            requestProgressManager.notifyOfRequestProcessed(request, listRequestListener);
             return;
         } else {
             requestRunner.executeRequest(request);

--- a/robospice-core-parent/robospice/src/main/java/com/octo/android/robospice/request/RequestProgressManager.java
+++ b/robospice-core-parent/robospice/src/main/java/com/octo/android/robospice/request/RequestProgressManager.java
@@ -82,7 +82,7 @@ public class RequestProgressManager {
         final Set<RequestListener<?>> listeners = mapRequestToRequestListener.get(request);
         notifyListenersOfRequestProgress(request, listeners, RequestStatus.COMPLETE);
         requestProgressReporter.notifyListenersOfRequestSuccess(request, result, listeners);
-        notifyOfRequestProcessed(request);
+        notifyOfRequestProcessed(request, listeners);
     }
 
     public <T> void notifyListenersOfRequestFailure(final CachedSpiceRequest<T> request, final SpiceException e) {
@@ -90,7 +90,7 @@ public class RequestProgressManager {
         notifyListenersOfRequestProgress(request, listeners, RequestStatus.COMPLETE);
 
         requestProgressReporter.notifyListenersOfRequestFailure(request, e, listeners);
-        notifyOfRequestProcessed(request);
+        notifyOfRequestProcessed(request, listeners);
     }
 
     public void notifyListenersOfRequestCancellation(final CachedSpiceRequest<?> request, final Set<RequestListener<?>> listeners) {
@@ -98,7 +98,7 @@ public class RequestProgressManager {
         notifyListenersOfRequestProgress(request, listeners, RequestStatus.COMPLETE);
 
         requestProgressReporter.notifyListenersOfRequestCancellation(request, listeners);
-        notifyOfRequestProcessed(request);
+        notifyOfRequestProcessed(request, listeners);
     }
 
     /**
@@ -130,14 +130,14 @@ public class RequestProgressManager {
         this.spiceServiceListenerSet.remove(spiceServiceServiceListener);
     }
 
-    public void notifyOfRequestProcessed(final CachedSpiceRequest<?> request) {
+    public void notifyOfRequestProcessed(final CachedSpiceRequest<?> request, Set<RequestListener<?>> listeners) {
         Ln.v("Removing %s  size is %d", request, mapRequestToRequestListener.size());
         mapRequestToRequestListener.remove(request);
 
         checkAllRequestComplete();
         synchronized (spiceServiceListenerSet) {
             for (final SpiceServiceServiceListener spiceServiceServiceListener : spiceServiceListenerSet) {
-                spiceServiceServiceListener.onRequestProcessed(request);
+                spiceServiceServiceListener.onRequestProcessed(request, listeners);
             }
         }
     }

--- a/robospice-core-parent/robospice/src/main/java/com/octo/android/robospice/request/listener/SpiceServiceServiceListener.java
+++ b/robospice-core-parent/robospice/src/main/java/com/octo/android/robospice/request/listener/SpiceServiceServiceListener.java
@@ -3,11 +3,13 @@ package com.octo.android.robospice.request.listener;
 import com.octo.android.robospice.SpiceService;
 import com.octo.android.robospice.request.CachedSpiceRequest;
 
+import java.util.Set;
+
 /**
  * Defines the behavior of a listener that will be notified of request
  * processing by the {@link SpiceService}.
  * @author sni
  */
 public interface SpiceServiceServiceListener {
-    void onRequestProcessed(CachedSpiceRequest<?> cachedSpiceRequest);
+    void onRequestProcessed(CachedSpiceRequest<?> cachedSpiceRequest, Set<RequestListener<?>>listeners);
 }


### PR DESCRIPTION
Hello!
I started to use RoboSpice library in my project and I liked its design and usability very much.
But I have faced a problem: when I execute many similar requests, I have a great memory leak after them. After investigating this problem I have found that memory leak is in mapPendingRequestToRequestListener field in SpiceManager class. Some listeners are not removed from this map. It is so because this field is IdentityHashMap, but remove method is called only for one of aggregated requests. So I changed code a little to remove all listeners after execution.
