### PR TITLE
Remove unnecessary synchronization

### DIFF
--- a/robospice-core-parent/robospice/src/main/java/com/octo/android/robospice/request/RequestProgressManager.java
+++ b/robospice-core-parent/robospice/src/main/java/com/octo/android/robospice/request/RequestProgressManager.java
@@ -135,10 +135,8 @@ public class RequestProgressManager {
         mapRequestToRequestListener.remove(request);
 
         checkAllRequestComplete();
-        synchronized (spiceServiceListenerSet) {
-            for (final SpiceServiceServiceListener spiceServiceServiceListener : spiceServiceListenerSet) {
-                spiceServiceServiceListener.onRequestProcessed(request);
-            }
+        for (final SpiceServiceServiceListener spiceServiceServiceListener : spiceServiceListenerSet) {
+            spiceServiceServiceListener.onRequestProcessed(request);
         }
     }
 


### PR DESCRIPTION
Collection is synchronized by default
        spiceServiceListenerSet = Collections.synchronizedSet(new HashSet<SpiceServiceServiceListener>());
There is no need to do external locking
