### PR TITLE
Fix for fast switching

### DIFF
--- a/robospice-core-parent/robospice/src/main/java/com/octo/android/robospice/SpiceManager.java
+++ b/robospice-core-parent/robospice/src/main/java/com/octo/android/robospice/SpiceManager.java
@@ -247,6 +247,7 @@ public class SpiceManager implements Runnable {
                     sendRequestToService(requestQueue.take());
                 } catch (final InterruptedException ex) {
                     Ln.d("Interrupted while waiting for new request.");
+                    break;
                 }
             }
         } catch (final InterruptedException e) {


### PR DESCRIPTION
I have found one more wonderful bug.
I call start() of SpiceManager in onStart() of Fragment and shouldStop() in onStop() of Fragment.
So when device screen is getting locked shouldStop() is called and when it is getting unlocked start() is called.
If I press lock button many times quickly, SpiceManager is getting stopped and then restarted many times.
Runner thread of it is getting interrupted and than created again.
But if start() is called immediately after stop() there is a chance that isStopped field will became false again because of new call of start().
So previous thread will not be stopped at all.
