### PR TITLE
spicemanager: always use isStarted() when checking if started.

### DIFF
--- a/robospice-core-parent/robospice/src/main/java/com/octo/android/robospice/SpiceManager.java
+++ b/robospice-core-parent/robospice/src/main/java/com/octo/android/robospice/SpiceManager.java
@@ -190,7 +190,7 @@ public class SpiceManager implements Runnable {
      */
     public synchronized void start(final Context context) {
         this.contextWeakReference = new WeakReference<Context>(context);
-        if (runner != null) {
+        if (isStarted()) {
             throw new IllegalStateException("Already started.");
         } else {
             executorService = Executors.newFixedThreadPool(getThreadCount(), new MinPriorityThreadFactory());


### PR DESCRIPTION
In my `SpiceManager` subclass, I override `start(Context)` and check if the manager is started to avoid receiving an `IllegalStateException`:

``` java
public class NetRequestManager extends SpiceManager {
@Override
    public synchronized void start(Context context) {
        if (!isStarted())
            super.start(context);
    }
}
```

However, there was a case where a user of my robospice 1.4.7-based application received exactly this:

```
java.lang.IllegalStateException: Already started.
        at com.octo.android.robospice.SpiceManager.start(SpiceManager.java:194)
        at gr.p.a.NetRequestManager.start(NetRequestManager.java:29)
```

Since `SpiceManager.start()` checks the value of `runner` instead of using `isStarted()`, it seems that in rare occasions the former may not be `null` while the latter is `false`. So, I changed the check to use `isStarted()`.

I believe this is within the "spirit" of the library, since this is the only place where the value of `runner` is checked. Everywhere else the check is done using either `isStopped` or `isStarted()`. I have also run all the tests and none fails. However, I do not know _why_ this occurs and what it means to create a new `runner` while the existing is not `null`.
