### PR TITLE
Fixed context leak in the event that the manager is not stopped

### DIFF
--- a/robospice-core-parent/robospice/src/main/java/com/octo/android/robospice/SpiceManager.java
+++ b/robospice-core-parent/robospice/src/main/java/com/octo/android/robospice/SpiceManager.java
@@ -230,13 +230,7 @@ public class SpiceManager implements Runnable {
 
     @Override
     public void run() {
-        // start the service it is not started yet.
-        Context context = contextWeakReference.get();
-        if (context != null) {
-            checkServiceIsProperlyDeclaredInAndroidManifest(context);
-            final Intent intent = new Intent(context, spiceServiceClass);
-            context.startService(intent);
-        } else {
+        if (!tryToStartService()) {
             Ln.d("Service was not started as Activity died prematurely");
             isStopped = true;
             return;
@@ -1138,6 +1132,21 @@ public class SpiceManager implements Runnable {
     /** For testing purpose. */
     protected boolean isBound() {
         return spiceService != null;
+    }
+    
+    private boolean tryToStartService() {
+        boolean success = false;
+
+        // start the service it is not started yet.
+        Context context = contextWeakReference.get();
+        if (context != null) {
+            checkServiceIsProperlyDeclaredInAndroidManifest(context);
+            final Intent intent = new Intent(context, spiceServiceClass);
+            context.startService(intent);
+            success = true;
+        }
+
+        return success;
     }
 
     private void bindToService(final Context context) {


### PR DESCRIPTION
The context is being referenced in the runner thread during the blocking call to:
`sendRequestToService(requestQueue.take());`

This fix ensures that the context is not strongly referenced. This bug is only seen when the manager is not properly stopped with the activity/fragment lifecycle.
