### PR TITLE
LruCacheObjectPersister’s getCreationDateInCache() does not ask fallback for date

### DIFF
--- a/robospice-cache-parent/robospice-cache-test/src/main/java/com/octo/android/robospice/persistence/memory/LruCacheObjectPersisterTest.java
+++ b/robospice-cache-parent/robospice-cache-test/src/main/java/com/octo/android/robospice/persistence/memory/LruCacheObjectPersisterTest.java
@@ -63,4 +63,9 @@ public class LruCacheObjectPersisterTest extends AndroidTestCase {
         assertNotNull(testPersisterWithFallback.loadDataFromCache(TEST_CACHE_KEY_1, DurationInMillis.ALWAYS_RETURNED));
     }
 
+    public void testGetCreationDateInCache_works_if_data_only_in_fallback() throws Exception {
+        testPersisterWithFallback.saveDataToCacheAndReturnData(TEST_DATA, TEST_CACHE_KEY_1);
+        testPersisterWithFallback.getLruCache().evictAll();
+        assertTrue(testPersisterWithFallback.getCreationDateInCache(TEST_CACHE_KEY_1) > 0);
+    }
 }

--- a/robospice-cache-parent/robospice-cache/src/main/java/com/octo/android/robospice/persistence/memory/LruCacheObjectPersister.java
+++ b/robospice-cache-parent/robospice-cache/src/main/java/com/octo/android/robospice/persistence/memory/LruCacheObjectPersister.java
@@ -102,6 +102,10 @@ public class LruCacheObjectPersister<T> extends ObjectPersister<T> {
 
         if (cacheItem != null) {
             return cacheItem.getCreationDate();
+        } else {
+            if (decoratedPersister != null) {
+                return decoratedPersister.getCreationDateInCache(cacheKey);
+            }
         }
         throw new CacheLoadingException("Data could not be found in cache for cacheKey=" + cacheKey);
     }


### PR DESCRIPTION
I was using a LruCacheObjectPersister that decorated an InFileObjectPersister (fallback). When calling getCreationDateInCache(), LruCacheObjectPersister threw an exception about not finding the data although I could see that the cached file was existing. I expected LruCacheObjectPersister to return the last-modified of that cache file on disk.
Here's a patch + test to fix this.
