### PR TITLE
Added support for HeaderListViewAdapter in SpiceListView.

### DIFF
--- a/extensions/robospice-ui-spicelist-parent/robospice-ui-spicelist/src/main/java/com/octo/android/robospice/spicelist/SpiceListView.java
+++ b/extensions/robospice-ui-spicelist-parent/robospice-ui-spicelist/src/main/java/com/octo/android/robospice/spicelist/SpiceListView.java
@@ -54,19 +54,6 @@ public class SpiceListView extends ListView {
         super.setAdapter(adapter);
     }
 
-    @Override
-    public BaseSpiceArrayAdapter<?> getAdapter() {
-        ListAdapter adapter = super.getAdapter();
-
-        if (adapter == null) {
-            return null;
-        } else if (adapter instanceof  BaseSpiceArrayAdapter<?>) {
-            return (BaseSpiceArrayAdapter<?>) adapter;
-        } else {
-            return (BaseSpiceArrayAdapter<?>) ((HeaderViewListAdapter) adapter).getWrappedAdapter();
-        }
-    }
-
     // ----------------------------
     // --- PRIVATE API
     // ----------------------------
@@ -92,8 +79,15 @@ public class SpiceListView extends ListView {
             if (wrappedListener != null) {
                 wrappedListener.onScrollStateChanged(view, scrollState);
             }
-            if (getAdapter() != null) {
-                getAdapter().setNetworkFetchingAllowed(scrollState == SCROLL_STATE_IDLE);
+            ListAdapter adapter = getAdapter();
+            if (adapter != null) {
+                BaseSpiceArrayAdapter<?> spiceArrayAdapter;
+                if (adapter instanceof  BaseSpiceArrayAdapter<?>) {
+                    spiceArrayAdapter = (BaseSpiceArrayAdapter<?>) adapter;
+                } else {
+                    spiceArrayAdapter = (BaseSpiceArrayAdapter<?>) ((HeaderViewListAdapter) adapter).getWrappedAdapter();
+                }
+                spiceArrayAdapter.setNetworkFetchingAllowed(scrollState == SCROLL_STATE_IDLE);
             }
         }
 


### PR DESCRIPTION
The current implementation throws a ClassCastException ungracefully on ListView#setAdapter when a header has been added using the ListView#addHeaderView method. The issue is, Android automatically wraps the adapter to a http://developer.android.com/reference/android/widget/HeaderViewListAdapter.html in that scenario.

The improvement is that the SpiceListView deals correctly with that issue by examining the instance class of the adapter and acting accordingly.
