### PR TITLE
Close input stream in RetrofitObjectPersister.readCacheDataFromFile (master)

### DIFF
--- a/extensions/robospice-retrofit-parent/robospice-retrofit/src/main/java/com/octo/android/robospice/persistence/retrofit/RetrofitObjectPersister.java
+++ b/extensions/robospice-retrofit-parent/robospice-retrofit/src/main/java/com/octo/android/robospice/persistence/retrofit/RetrofitObjectPersister.java
@@ -92,8 +92,10 @@ public class RetrofitObjectPersister<T> extends InFileObjectPersister<T> {
     @SuppressWarnings("unchecked")
     @Override
     protected T readCacheDataFromFile(File file) throws CacheLoadingException {
+        InputStream fileInputStream = null;
         try {
-            final byte[] body = IOUtils.toByteArray(new FileInputStream(file));
+            fileInputStream = new FileInputStream(file);
+            final byte[] body = IOUtils.toByteArray(fileInputStream);
             TypedInput typedInput = new TypedInput() {
 
                 @Override
@@ -119,6 +121,8 @@ public class RetrofitObjectPersister<T> extends InFileObjectPersister<T> {
             return null;
         } catch (Exception e) {
             throw new CacheLoadingException(e);
+        } finally {
+            IOUtils.closeQuietly(fileInputStream);
         }
     }
 }


### PR DESCRIPTION
Error when StrictMode enabled.

E/StrictMode﹕ A resource was acquired at attached stack trace but never released. See java.io.Closeable for information on avoiding resource leaks.
java.lang.Throwable: Explicit termination method 'close' not called
at dalvik.system.CloseGuard.open(CloseGuard.java:184)
at java.io.FileInputStream.(FileInputStream.java:80)
at com.octo.android.robospice.persistence.retrofit.RetrofitObjectPersister.readCacheDataFromFile(RetrofitObjectPersister.java:96)
at com.octo.android.robospice.persistence.file.InFileObjectPersister.loadDataFromCache(InFileObjectPersister.java:160)
at com.octo.android.robospice.persistence.CacheManager.loadDataFromCache(CacheManager.java:68)
at com.octo.android.robospice.request.DefaultRequestRunner.loadDataFromCache(DefaultRequestRunner.java:239)
at com.octo.android.robospice.request.DefaultRequestRunner.processRequest(DefaultRequestRunner.java:88)
at com.octo.android.robospice.request.DefaultRequestRunner$1.run(DefaultRequestRunner.java:201)
at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:390)
at java.util.concurrent.FutureTask.run(FutureTask.java:234)
at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1080)
at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:573)
at java.lang.Thread.run(Thread.java:856)
