### PR TITLE
Replace Application with Context in RoboSpiceDatabaseHelper

### DIFF
--- a/extensions/robospice-ormlite-parent/robospice-ormlite/src/main/java/com/octo/android/robospice/persistence/ormlite/RoboSpiceDatabaseHelper.java
+++ b/extensions/robospice-ormlite-parent/robospice-ormlite/src/main/java/com/octo/android/robospice/persistence/ormlite/RoboSpiceDatabaseHelper.java
@@ -34,8 +34,8 @@ public class RoboSpiceDatabaseHelper extends OrmLiteSqliteOpenHelper {
         return cacheKey.substring(cacheKey.indexOf('_') + 1);
     }
 
-    public RoboSpiceDatabaseHelper(Application application, String databaseName, int databaseVersion) {
-        super(application, databaseName, null, databaseVersion);
+    public RoboSpiceDatabaseHelper(Context context, String databaseName, int databaseVersion) {
+        super(context, databaseName, null, databaseVersion);
     }
 
     public RoboSpiceDatabaseHelper(Context context, String databaseName, SQLiteDatabase.CursorFactory factory, int databaseVersion) {


### PR DESCRIPTION
Using Application makes it hard to use this class in unit tests - the super call only requires Context anyway
