### PR TITLE
Changed Requests to only retry on network down when the request was already in progress

### DIFF
--- a/robospice-core-parent/robospice/src/main/java/com/octo/android/robospice/request/CachedSpiceRequest.java
+++ b/robospice-core-parent/robospice/src/main/java/com/octo/android/robospice/request/CachedSpiceRequest.java
@@ -22,6 +22,7 @@ public class CachedSpiceRequest<RESULT> extends SpiceRequest<RESULT> {
     private boolean isProcessable = true;
     private boolean isAcceptingDirtyCache;
     private boolean isOffline;
+    private boolean isLoadDataFromNetworkCalledBefore;
 
     public CachedSpiceRequest(final SpiceRequest<RESULT> spiceRequest, final Object requestCacheKey, final long cacheDuration) {
         super(spiceRequest.getResultType());
@@ -42,6 +43,8 @@ public class CachedSpiceRequest<RESULT> extends SpiceRequest<RESULT> {
 
     @Override
     public RESULT loadDataFromNetwork() throws Exception {
+        isLoadDataFromNetworkCalledBefore = true;
+
         return spiceRequest.loadDataFromNetwork();
     }
 
@@ -125,6 +128,14 @@ public class CachedSpiceRequest<RESULT> extends SpiceRequest<RESULT> {
         return spiceRequest.getProgress();
     }
 
+    /**
+     * Has this request had a load data from network attempt before?
+     * @return false if the call has never been attempted before (including failed attempts)
+     */
+    public boolean isLoadDataFromNetworkCalledBefore() {
+        return isLoadDataFromNetworkCalledBefore;
+    }
+
     @Override
     public void setPriority(int priority) {
         spiceRequest.setPriority(priority);
@@ -155,7 +166,7 @@ public class CachedSpiceRequest<RESULT> extends SpiceRequest<RESULT> {
     public String toString() {
         return "CachedSpiceRequest [requestCacheKey=" + requestCacheKey + ", cacheDuration=" + cacheDuration + ", spiceRequest=" + spiceRequest + "]";
     }
-    
+
     // --------------------------------------------------------------------
     //  COMPARISON METHODS : THEY DEFINE AGGREGATION OF SPICE REQUESTS.
     // --------------------------------------------------------------------

--- a/robospice-core-parent/robospice/src/main/java/com/octo/android/robospice/request/DefaultRequestRunner.java
+++ b/robospice-core-parent/robospice/src/main/java/com/octo/android/robospice/request/DefaultRequestRunner.java
@@ -131,8 +131,12 @@ public class DefaultRequestRunner implements RequestRunner {
             Ln.e("Network is down.");
 
             if (!request.isCancelled()) {
-                // don't retry when there is no network
-                requestProgressManager.notifyListenersOfRequestFailure(request, new NoNetworkException());
+                if (!request.isLoadDataFromNetworkCalledBefore()) {
+                    // don't retry when there has been no indication of an active network before
+                    requestProgressManager.notifyListenersOfRequestFailure(request, new NoNetworkException());
+                } else {
+                    handleRetry(request, new NoNetworkException());
+                }
             }
 
             printRequestProcessingDuration(startTime, request);


### PR DESCRIPTION
Linked to #290 and #286.

This is potentially a better solution for #286 whereby if the network is unavailable to start off with it will fail immediately. However, if the network was available and the request was in progress but it then failed and there's no network anymore then it should retry.
