### PR TITLE
request processor listeners loss fix

### DIFF
--- a/robospice-core-parent/robospice/src/main/java/com/octo/android/robospice/request/RequestProcessor.java
+++ b/robospice-core-parent/robospice/src/main/java/com/octo/android/robospice/request/RequestProcessor.java
@@ -37,10 +37,7 @@ public class RequestProcessor {
 
     /**
      * Build a request processor using a custom. This feature has been
-     * implemented follwing a feature request from Riccardo Ciovati.
-     * @param context
-     *            the context on which {@link SpiceRequest} will provide their
-     *            results.
+     * implemented following a feature request from Riccardo Ciovati.
      * @param cacheManager
      *            the {@link CacheManager} that will be used to retrieve
      *            requests' result and store them.
@@ -78,17 +75,21 @@ public class RequestProcessor {
         }
 
         boolean aggregated = false;
-        Set<RequestListener<?>> listRequestListenerForThisRequest = mapRequestToRequestListener.get(request);
+        Set<RequestListener<?>> listRequestListenerForThisRequest;
 
-        if (listRequestListenerForThisRequest == null) {
-            if (request.isProcessable()) {
-                Ln.d("Adding entry for type %s and cacheKey %s.", request.getResultType(), request.getRequestCacheKey());
-                listRequestListenerForThisRequest = Collections.synchronizedSet(new HashSet<RequestListener<?>>());
-                this.mapRequestToRequestListener.put(request, listRequestListenerForThisRequest);
+        synchronized (mapRequestToRequestListener) {
+            listRequestListenerForThisRequest = mapRequestToRequestListener.get(request);
+
+            if (listRequestListenerForThisRequest == null) {
+                if (request.isProcessable()) {
+                    Ln.d("Adding entry for type %s and cacheKey %s.", request.getResultType(), request.getRequestCacheKey());
+                    listRequestListenerForThisRequest = Collections.synchronizedSet(new HashSet<RequestListener<?>>());
+                    this.mapRequestToRequestListener.put(request, listRequestListenerForThisRequest);
+                }
+            } else {
+                Ln.d("Request for type %s and cacheKey %s already exists.", request.getResultType(), request.getRequestCacheKey());
+                aggregated = true;
             }
-        } else {
-            Ln.d("Request for type %s and cacheKey %s already exists.", request.getResultType(), request.getRequestCacheKey());
-            aggregated = true;
         }
 
         if (listRequestListener != null && listRequestListenerForThisRequest != null) {


### PR DESCRIPTION
Hello!
It's me again with strange multithreaded bugs :)
I've noticed that sometimes my request listeners are not called and then have found these lines in log:

04-20 04:11:56.448  14869-14928/ru.car2car.droid D/RequestProcessor.java:85﹕ 04:11:56.454 SpiceManagerThread 0 Adding entry for type class ru.car2car.droid.requests.api.methods.user.UserProfileRequest$Response and cacheKey http#3A#2F#2Fcar2car.ru#2Fapi#2Fuser#2Fprofile#2F#3Fsession_id#3D535313aa563d22.57601009#0b4dc5b937dd4d3e02881fb3ff20331b.
04-20 04:11:56.448  14869-14927/ru.car2car.droid D/RequestProcessor.java:85﹕ 04:11:56.455 SpiceManagerThread 0 Adding entry for type class ru.car2car.droid.requests.api.methods.user.UserProfileRequest$Response and cacheKey http#3A#2F#2Fcar2car.ru#2Fapi#2Fuser#2Fprofile#2F#3Fsession_id#3D535313aa563d22.57601009#0b4dc5b937dd4d3e02881fb3ff20331b.

It was strange that same log message was repeated almost at same time.
In code I found that request processor has not synchronized adding requests.
I also have written a test that failes with old version and passes with new.

P.S. You asked me to tell when project using Robospice will be released to market. So it's there: https://play.google.com/store/apps/details?id=ru.stream.droid. I think later I can give links to some more our projects with Robospice.
