### PR TITLE
Fix broken markdown in Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ The RoboSpice team proposes a lot of sample applications in [their own GitHub re
 
 We also propose a few demo : 
 * [RoboSpice Motivations](http://goo.gl/pzqH4) : a pedagogical app that explains the motivations behind RoboSpice.
-* and [a demo that illustrates non-network related requests (offline)](](https://play.google.com/store/apps/details?id=com.octo.android.robospice.sample.offline#?t=W251bGwsMSwxLDIxMiwiY29tLm9jdG8uYW5kcm9pZC5yb2Jvc3BpY2Uuc2FtcGxlLm9mZmxpbmUiXQ..).
+* and [a demo that illustrates non-network related requests (offline)](https://play.google.com/store/apps/details?id=com.octo.android.robospice.sample.offline).
 
 A project initiated by Octo Technology 
 -------------------------------------


### PR DESCRIPTION
The markdown to format the link to the offline demo app was broken.
