### PR TITLE
remove multiple unbinding

### DIFF
--- a/robospice-core-parent/robospice/src/main/java/com/octo/android/robospice/SpiceManager.java
+++ b/robospice-core-parent/robospice/src/main/java/com/octo/android/robospice/SpiceManager.java
@@ -331,7 +331,6 @@ public class SpiceManager implements Runnable {
             long end = System.currentTimeMillis();
             Ln.d("Runner join time (ms) when should stop %d", end - start);
         }
-        isUnbinding = false;
         unbindFromService(contextWeakReference.get());
         this.runner = null;
         this.executorService.shutdown();


### PR DESCRIPTION
Hello!
As I can see, in stephanenicolas@4ad00a94a655e65743b44391ac013f54d98022a9 this line was added. But I don't understand why it is needed. Existance of this line can lead to multiple unbinding what is not good in my opinion.
This field is set to false on every unbind, so there is no need to do it explicitly.
