### PR TITLE
remove unbinding before removing listeners

### DIFF
--- a/robospice-core-parent/robospice/src/main/java/com/octo/android/robospice/SpiceManager.java
+++ b/robospice-core-parent/robospice/src/main/java/com/octo/android/robospice/SpiceManager.java
@@ -265,8 +265,6 @@ public class SpiceManager implements Runnable {
             }
         } catch (final InterruptedException e) {
             Ln.d(e, "Interrupted while waiting for acquiring service.");
-        } finally {
-            unbindFromService(contextWeakReference.get());
         }
     }
 


### PR DESCRIPTION
Hello!
In stephanenicolas@4ad00a94a655e65743b44391ac013f54d98022a9 while working on issue #246
setting isStopped to true was added in method shouldStopAndJoin before removing listeners (https://github.com/stephanenicolas/robospice/blob/afce520c89a8e70c34b73b29b5a8a9ccbf57ad10/robospice-core-parent/robospice/src/main/java/com/octo/android/robospice/SpiceManager.java#L320).
But when isStopped becomes true, spice manager thread stops and while loops ends, so finally block is called and service unbinds (https://github.com/stephanenicolas/robospice/blob/afce520c89a8e70c34b73b29b5a8a9ccbf57ad10/robospice-core-parent/robospice/src/main/java/com/octo/android/robospice/SpiceManager.java#L269). So next line in shouldStopAndJoin - removing listeners - may fails, because service is already unbinded. Actually the problem is that listeners are called when spicemanager is already stopped.
It is not so easy to reproduce, more chances on fast phones with multiple cores, such as Samsung Galaxy S4.
I can't invent any suitable test for this, I think that https://github.com/stephanenicolas/robospice/blob/afce520c89a8e70c34b73b29b5a8a9ccbf57ad10/robospice-core-parent/robospice-core-test/src/main/java/com/octo/android/robospice/SpiceManagerTest.java#L499 is already suitable, but it doesn't show the problem. Maybe you can invent better test?
I think that unbinding service in finally block is not needed because shouldStop method is called every time when thread gets interrupted. So this way solves the problem very easily and quickly, but maybe you see more complex and right variant of solving.
