### PR TITLE
Dynamic thread pool for Spice Service, controlling core and max number of threads

### DIFF
--- a/robospice-core-parent/robospice-core-test/src/main/java/com/octo/android/robospice/SpiceServiceTest.java
+++ b/robospice-core-parent/robospice-core-test/src/main/java/com/octo/android/robospice/SpiceServiceTest.java
@@ -8,6 +8,8 @@ import android.test.suitebuilder.annotation.SmallTest;
 import com.octo.android.robospice.core.test.SpiceTestService;
 import com.octo.android.robospice.priority.PriorityThreadPoolExecutor;
 
+import java.util.concurrent.TimeUnit;
+
 //Thanks to http://stackoverflow.com/questions/2300029/servicetestcaset-getservice
 @SmallTest
 public class SpiceServiceTest extends ServiceTestCase<SpiceTestService> {
@@ -62,11 +64,36 @@ public class SpiceServiceTest extends ServiceTestCase<SpiceTestService> {
 
         // then
         assertTrue(getService().getExecutorService() instanceof PriorityThreadPoolExecutor);
-        PriorityThreadPoolExecutor executorService = (PriorityThreadPoolExecutor) getService().getExecutorService();
+        final PriorityThreadPoolExecutor executorService =
+                (PriorityThreadPoolExecutor) getService().getExecutorService();
 
-        assertEquals(getService().getThreadCount(), executorService.getCorePoolSize());
+        assertEquals(getService().getCoreThreadCount(), executorService.getCorePoolSize());
+        assertEquals(getService().getMaximumThreadCount(), executorService.getMaximumPoolSize());
+        assertEquals(getService().getThreadPriority(), executorService.getThreadFactory()
+                .newThread(null).getPriority());
+        assertEquals(getService().getKeepAliveTime(),
+                executorService.getKeepAliveTime(TimeUnit.NANOSECONDS));
+    }
 
-        assertEquals(getService().getThreadPriority(), executorService.getThreadFactory().newThread(null).getPriority());
+    public void testGetExecutorService_corethread_defaults() {
+        // given
+
+        // when
+        Intent startIntent = new Intent();
+        startIntent.setClass(getContext(), SpiceTestService.class);
+        startService(startIntent);
+
+        // then
+        assertTrue(getService().getExecutorService() instanceof PriorityThreadPoolExecutor);
+        final PriorityThreadPoolExecutor executorService =
+                (PriorityThreadPoolExecutor) getService().getExecutorService();
+
+        assertEquals(getService().getCoreThreadCount(), executorService.getCorePoolSize());
+        assertEquals(getService().getMaximumThreadCount(), executorService.getMaximumPoolSize());
+        assertEquals(getService().getThreadPriority(), executorService.getThreadFactory()
+                .newThread(null).getPriority());
+        assertEquals(getService().getKeepAliveTime(),
+                executorService.getKeepAliveTime(TimeUnit.NANOSECONDS));
     }
 
     public void testStops_shutsdown_executor_service() {

--- a/robospice-core-parent/robospice-core-test/src/main/java/com/octo/android/robospice/core/test/SpiceTestService.java
+++ b/robospice-core-parent/robospice-core-test/src/main/java/com/octo/android/robospice/core/test/SpiceTestService.java
@@ -20,6 +20,7 @@ import com.octo.android.robospice.stub.StringPersisterStub;
 public class SpiceTestService extends SpiceService {
 
     private static final int TEST_THREAD_COUNT = 3;
+    private static final int TEST_THREAD_KEEP_ALIVE_TIME = 1000;
     private static final int TEST_THREAD_PRIORITY = Thread.NORM_PRIORITY;
     
     @Override
@@ -56,8 +57,23 @@ public class SpiceTestService extends SpiceService {
     }
 
     @Override
+    public int getCoreThreadCount() {
+        return TEST_THREAD_COUNT;
+    }
+
+    @Override
+    public int getMaximumThreadCount() {
+        return TEST_THREAD_COUNT;
+    }
+
+    @Override
     public int getThreadPriority() {
         return TEST_THREAD_PRIORITY;
+    }
+
+    @Override
+    public int getKeepAliveTime() {
+        return TEST_THREAD_KEEP_ALIVE_TIME;
     }
 
     @Override
@@ -76,5 +92,4 @@ public class SpiceTestService extends SpiceService {
     public RequestProcessor getRequestProcessor() {
         return super.getRequestProcessor();
     }
-
 }

--- a/robospice-core-parent/robospice/src/main/java/com/octo/android/robospice/priority/PausableThreadPoolExecutor.java
+++ b/robospice-core-parent/robospice/src/main/java/com/octo/android/robospice/priority/PausableThreadPoolExecutor.java
@@ -15,6 +15,21 @@ public class PausableThreadPoolExecutor extends ThreadPoolExecutor {
     /**
      * Creates a thread pool executor with a
      * {@link PausablePriorityBlockingQueue}.
+     * @param corePoolSize
+     *            the size of the pool of threads.
+     * @param maxPoolSize
+     *            the size of the pool of threads.
+     * @param threadPriority
+     *            the priority of threads created as defined by
+     *            {@link Thread#setPriority(int)}.
+     */
+    public PausableThreadPoolExecutor(int corePoolSize, int maxPoolSize, int threadPriority) {
+        super(corePoolSize, maxPoolSize, 0, TimeUnit.NANOSECONDS, new PausablePriorityBlockingQueue<Runnable>(), new CustomizablePriorityThreadFactory(threadPriority));
+    }
+    
+    /**
+     * Creates a thread pool executor with a
+     * {@link PausablePriorityBlockingQueue}.
      * @param poolSize
      *            the size of the pool of threads.
      * @param threadPriority

--- a/robospice-core-parent/robospice/src/main/java/com/octo/android/robospice/priority/PriorityThreadPoolExecutor.java
+++ b/robospice-core-parent/robospice/src/main/java/com/octo/android/robospice/priority/PriorityThreadPoolExecutor.java
@@ -18,6 +18,10 @@ public final class PriorityThreadPoolExecutor extends PausableThreadPoolExecutor
     // ----------------------------------
     // CONSTRUCTORS
     // ----------------------------------
+    public PriorityThreadPoolExecutor(int corePoolSize, int maxPoolSize,
+        int threadPriority) {
+        super(corePoolSize, maxPoolSize, threadPriority);
+    }
 
     public PriorityThreadPoolExecutor(int poolSize, int threadPriority) {
         super(poolSize, threadPriority);
@@ -30,6 +34,11 @@ public final class PriorityThreadPoolExecutor extends PausableThreadPoolExecutor
     // ----------------------------------
     // API
     // ----------------------------------
+    public static PriorityThreadPoolExecutor getPriorityExecutor(
+        int nCoreThreads, int maxPoolSize, int threadPriority) {
+        return new PriorityThreadPoolExecutor(nCoreThreads, maxPoolSize,
+            threadPriority);
+    }
 
     public static PriorityThreadPoolExecutor getPriorityExecutor(int nThreads, int threadPriority) {
         return new PriorityThreadPoolExecutor(nThreads, threadPriority);


### PR DESCRIPTION
Hi,

first of all, thank you for this incredible lib, it is very very useful for Android.

In something I am involved, we wanted to be able to configure the CorePoolSize and MaximumPoolSize on the Thread Pool Executor of the Spice Service.

I implemented this change on https://github.com/jorgevila/robospice/compare/stephanenicolas:master...dynamicThreadPool

creating two new methods getCoreThreadCount and getMaximumThreadCount that the user can override to modify these values.

I thought it could be interesting for you.

Best Regards.
