### PR TITLE
fixed NPE when cache folder is empty

### DIFF
--- a/robospice-cache-parent/robospice-cache/src/main/java/com/octo/android/robospice/persistence/file/InFileObjectPersister.java
+++ b/robospice-cache-parent/robospice-cache/src/main/java/com/octo/android/robospice/persistence/file/InFileObjectPersister.java
@@ -4,6 +4,7 @@ import java.io.File;
 import java.io.FileFilter;
 import java.io.FilenameFilter;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 
 import roboguice.util.temp.Ln;
@@ -108,6 +109,9 @@ public abstract class InFileObjectPersister<T> extends ObjectPersister<T> {
                 return filename.startsWith(prefix);
             }
         });
+        if (cacheFileNameList == null) {
+            return Collections.emptyList();
+        }
         List<Object> result = new ArrayList<Object>(cacheFileNameList.length);
         for (String cacheFileName : cacheFileNameList) {
             String cacheKey = cacheFileName.substring(prefixLength);


### PR DESCRIPTION
InFileObjectPersister throws NPE from line 112

```
    List<Object> result = new ArrayList<Object>(cacheFileNameList.length);
```

The problem is with the 'cacheFileNameList'  array that is returned from the following line

String[] cacheFileNameList = getCacheFolder().list(new FilenameFilter() {

if this array is null which could be true in some situations than a NPE is thrown on line 112. 

It can be reproduced by clearing app cache from settings and try to use the app, you will see app crash.
