### PR TITLE
added PendingRequestListener::onRequestAttached

### DIFF
--- a/robospice-core-parent/robospice-core-test/src/main/java/com/octo/android/robospice/stub/PendingRequestListenerWithProgressStub.java
+++ b/robospice-core-parent/robospice-core-test/src/main/java/com/octo/android/robospice/stub/PendingRequestListenerWithProgressStub.java
@@ -1,10 +1,14 @@
 package com.octo.android.robospice.stub;
 
 import com.octo.android.robospice.request.listener.PendingRequestListener;
+import com.octo.android.robospice.request.CachedSpiceRequest;
 
 public class PendingRequestListenerWithProgressStub<T> extends RequestListenerWithProgressStub<T> implements PendingRequestListener<T> {
 
     private boolean isRequestNotFound = false;
+
+    private CachedSpiceRequest<?> attachedRequest;
+
 
     @Override
     public void onRequestNotFound() {
@@ -13,5 +17,14 @@ public class PendingRequestListenerWithProgressStub<T> extends RequestListenerWi
 
     public boolean isRequestNotFound() {
         return isRequestNotFound;
+    }
+
+    @Override
+    public void onRequestAttached(CachedSpiceRequest<?> request) {
+        attachedRequest = request;
+    }
+
+    public CachedSpiceRequest<?> getAttachedRequest() {
+        return attachedRequest;
     }
 }

--- a/robospice-core-parent/robospice/src/main/java/com/octo/android/robospice/request/listener/PendingRequestListener.java
+++ b/robospice-core-parent/robospice/src/main/java/com/octo/android/robospice/request/listener/PendingRequestListener.java
@@ -1,5 +1,7 @@
 package com.octo.android.robospice.request.listener;
 
+import com.octo.android.robospice.request.CachedSpiceRequest;
+
 /**
  * Listens to a SpiceRequest that may be pending, or not. It will be notified of
  * request's result if such a request is pending, otherwise it will notified
@@ -8,4 +10,6 @@ package com.octo.android.robospice.request.listener;
 
 public interface PendingRequestListener<RESULT> extends RequestListener<RESULT> {
     void onRequestNotFound();
+
+    void onRequestAttached(CachedSpiceRequest<?> request);
 }


### PR DESCRIPTION
Hi!

In our project we need an ability to attach to a pending request after device configuration changed. For example, a user wants to cancel a long running request or it's necessary to show a dialog to a user if there is a pending request still.
I saw the discussion about this in #335 but no activity on the feature. I'm not very experienced in android development, so please be patient about my PR :) If I did it wrong, please advice how to improve it.

Thanks,
Nick
