### PR TITLE
fixed Verify error on Android 5.0

### DIFF
--- a/extensions/robospice-spring-android-parent/robospice-spring-android/src/main/java/com/octo/android/robospice/persistence/springandroid/SpringAndroidObjectPersister.java
+++ b/extensions/robospice-spring-android-parent/robospice-spring-android/src/main/java/com/octo/android/robospice/persistence/springandroid/SpringAndroidObjectPersister.java
@@ -40,9 +40,13 @@ public abstract class SpringAndroidObjectPersister<T> extends InFileObjectPersis
                 throw new CacheLoadingException(e);
             }
         }
-        if (!StringUtils.isEmpty(resultJson)) {
-            T result = deserializeData(resultJson);
-            return result;
+        try {
+            if (!StringUtils.isEmpty(resultJson)) {
+                T result = deserializeData(resultJson);
+                return result;
+            }
+        } catch (Exception e) {
+            throw new CacheLoadingException(e);
         }
         throw new CacheLoadingException("Unable to restore cache content : cache file is empty");
     }


### PR DESCRIPTION
Fixed Verify error reported by the class-verifier in dex2oat on Android 5.0 by removing unnecessary catch-clauses. See #387
