### PR TITLE
Logging fixes

### DIFF
--- a/extensions/robospice-google-http-client-parent/robospice-google-http-client/src/main/java/com/octo/android/robospice/persistence/googlehttpclient/json/JsonObjectPersister.java
+++ b/extensions/robospice-google-http-client-parent/robospice-google-http-client/src/main/java/com/octo/android/robospice/persistence/googlehttpclient/json/JsonObjectPersister.java
@@ -55,7 +55,7 @@ public final class JsonObjectPersister<T> extends InFileObjectPersister<T> {
         } catch (FileNotFoundException e) {
             // Should not occur (we test before if file exists)
             // Do not throw, file is not cached
-            Ln.w("file " + file.getAbsolutePath() + " does not exists", e);
+            Ln.w(e, "file %s does not exists", file.getAbsolutePath());
             return null;
         } catch (Exception e) {
             throw new CacheLoadingException(e);
@@ -73,9 +73,9 @@ public final class JsonObjectPersister<T> extends InFileObjectPersister<T> {
                         try {
                             saveData(data, cacheKey);
                         } catch (IOException e) {
-                            Ln.e(e, "An error occured on saving request " + cacheKey + " data asynchronously");
+                            Ln.e(e, "An error occured on saving request %s data asynchronously", cacheKey);
                         } catch (CacheSavingException e) {
-                            Ln.e(e, "An error occured on saving request " + cacheKey + " data asynchronously");
+                            Ln.e(e, "An error occured on saving request %s data asynchronously", cacheKey);
                         }
                     };
                 };

--- a/extensions/robospice-okhttp-parent/robospice-okhttp/src/main/java/com/octo/android/robospice/request/okhttp/simple/OkHttpSimpleTextRequest.java
+++ b/extensions/robospice-okhttp-parent/robospice-okhttp/src/main/java/com/octo/android/robospice/request/okhttp/simple/OkHttpSimpleTextRequest.java
@@ -24,7 +24,7 @@ public class OkHttpSimpleTextRequest extends OkHttpSpiceRequest<String> {
     @Override
     public String loadDataFromNetwork() throws Exception {
         try {
-            Ln.d("Call web service " + url);
+            Ln.d("Call web service %s", url);
             OkUrlFactory urlFactory = new OkUrlFactory(getOkHttpClient());
             HttpURLConnection connection = urlFactory.open(new URL(url));
             return IOUtils.toString(connection.getInputStream());

--- a/extensions/robospice-ormlite-parent/robospice-ormlite/src/main/java/com/octo/android/robospice/persistence/ormlite/InDatabaseObjectPersister.java
+++ b/extensions/robospice-ormlite-parent/robospice-ormlite/src/main/java/com/octo/android/robospice/persistence/ormlite/InDatabaseObjectPersister.java
@@ -57,7 +57,7 @@ public class InDatabaseObjectPersister<T, ID> extends ObjectPersister<T> {
         try {
             TableUtils.createTableIfNotExists(databaseHelper.getConnectionSource(), modelObjectType);
         } catch (SQLException e1) {
-            Ln.e(e1, "SQL Error while creating table for " + modelObjectType);
+            Ln.e(e1, "SQL Error while creating table for %s", modelObjectType);
         }
 
         try {

--- a/extensions/robospice-ormlite-parent/robospice-ormlite/src/main/java/com/octo/android/robospice/persistence/ormlite/InDatabaseObjectPersisterFactory.java
+++ b/extensions/robospice-ormlite-parent/robospice-ormlite/src/main/java/com/octo/android/robospice/persistence/ormlite/InDatabaseObjectPersisterFactory.java
@@ -47,7 +47,7 @@ public class InDatabaseObjectPersisterFactory extends ObjectPersisterFactory {
         try {
             TableUtils.createTableIfNotExists(databaseHelper.getConnectionSource(), clazz);
         } catch (SQLException e) {
-            Ln.e(e, "RoboSpice", "Could not create cache entry table");
+            Ln.e(e, "RoboSpice Could not create cache entry table");
         }
     }
 

--- a/extensions/robospice-retrofit-parent/robospice-retrofit/src/main/java/com/octo/android/robospice/persistence/retrofit/RetrofitObjectPersister.java
+++ b/extensions/robospice-retrofit-parent/robospice-retrofit/src/main/java/com/octo/android/robospice/persistence/retrofit/RetrofitObjectPersister.java
@@ -57,9 +57,9 @@ public class RetrofitObjectPersister<T> extends InFileObjectPersister<T> {
                         try {
                             saveData(data, cacheKey);
                         } catch (IOException e) {
-                            Ln.e(e, "An error occured on saving request " + cacheKey + " data asynchronously");
+                            Ln.e(e, "An error occured on saving request %s data asynchronously", cacheKey);
                         } catch (CacheSavingException e) {
-                            Ln.e(e, "An error occured on saving request " + cacheKey + " data asynchronously");
+                            Ln.e(e, "An error occured on saving request %s data asynchronously", cacheKey);
                         }
                     };
                 };
@@ -117,7 +117,7 @@ public class RetrofitObjectPersister<T> extends InFileObjectPersister<T> {
         } catch (FileNotFoundException e) {
             // Should not occur (we test before if file exists)
             // Do not throw, file is not cached
-            Ln.w("file " + file.getAbsolutePath() + " does not exists", e);
+            Ln.w(e, "file %s does not exists", file.getAbsolutePath());
             return null;
         } catch (Exception e) {
             throw new CacheLoadingException(e);

--- a/extensions/robospice-spring-android-parent/robospice-spring-android/src/main/java/com/octo/android/robospice/persistence/springandroid/SpringAndroidObjectPersister.java
+++ b/extensions/robospice-spring-android-parent/robospice-spring-android/src/main/java/com/octo/android/robospice/persistence/springandroid/SpringAndroidObjectPersister.java
@@ -48,7 +48,7 @@ public abstract class SpringAndroidObjectPersister<T> extends InFileObjectPersis
         } catch (FileNotFoundException e) {
             // Should not occur (we test before if file exists)
             // Do not throw, file is not cached
-            Ln.w("file " + file.getAbsolutePath() + " does not exists", e);
+            Ln.w(e, "file %s does not exists", file.getAbsolutePath());
             return null;
         } catch (CacheLoadingException e) {
             throw e;
@@ -70,9 +70,9 @@ public abstract class SpringAndroidObjectPersister<T> extends InFileObjectPersis
                         try {
                             saveData(data, cacheKey);
                         } catch (IOException e) {
-                            Ln.e(e, "An error occured on saving request " + cacheKey + " data asynchronously");
+                            Ln.e(e, "An error occured on saving request %s data asynchronously", cacheKey);
                         } catch (CacheSavingException e) {
-                            Ln.e(e, "An error occured on saving request " + cacheKey + " data asynchronously");
+                            Ln.e(e, "An error occured on saving request %s data asynchronously", cacheKey);
                         }
                     };
                 };

--- a/extensions/robospice-spring-android-parent/robospice-spring-android/src/main/java/com/octo/android/robospice/request/springandroid/SpringAndroidSpiceRequest.java
+++ b/extensions/robospice-spring-android-parent/robospice-spring-android/src/main/java/com/octo/android/robospice/request/springandroid/SpringAndroidSpiceRequest.java
@@ -32,7 +32,7 @@ public abstract class SpringAndroidSpiceRequest<RESULT> extends SpiceRequest<RES
      */
     public void cancel() {
         super.cancel();
-        Ln.w(SpringAndroidSpiceRequest.class.getName(), "Cancel can't be invoked directly on "
-            + SpringAndroidSpiceRequest.class.getName() + " requests. You must call SpiceManager.cancelAllRequests().");
+        Ln.w("%s Cancel can't be invoked directly on %s requests. You must call SpiceManager.cancelAllRequests().",
+                SpringAndroidSpiceRequest.class.getName(), SpringAndroidSpiceRequest.class.getName());
     }
 }

--- a/extensions/robospice-ui-spicelist-parent/robospice-ui-spicelist/src/main/java/com/octo/android/robospice/spicelist/BaseSpiceArrayAdapter.java
+++ b/extensions/robospice-ui-spicelist-parent/robospice-ui-spicelist/src/main/java/com/octo/android/robospice/spicelist/BaseSpiceArrayAdapter.java
@@ -209,7 +209,7 @@ public abstract class BaseSpiceArrayAdapter<T> extends ArrayAdapter<T> {
 
         @Override
         public final void onRequestFailure(final SpiceException spiceException) {
-            Ln.e(SpiceListItemView.class.getName(), "Unable to retrive image", spiceException);
+            Ln.e(spiceException, "%s Unable to retrive image", SpiceListItemView.class.getName());
             thumbImageView.setImageDrawable(defaultDrawable);
         }
 
@@ -297,7 +297,7 @@ public abstract class BaseSpiceArrayAdapter<T> extends ArrayAdapter<T> {
 
                 File tempThumbnailImageFile = bitmapRequest.getCacheFile();
                 tempThumbnailImageFileName = tempThumbnailImageFile.getAbsolutePath();
-                Ln.d("Filename : " + tempThumbnailImageFileName);
+                Ln.d("Filename : %s", tempThumbnailImageFileName);
 
                 if (!tempThumbnailImageFile.exists()) {
                     if (isNetworkFetchingAllowed) {

--- a/robospice-cache-parent/robospice-cache/src/main/java/com/octo/android/robospice/persistence/binary/InFileInputStreamObjectPersister.java
+++ b/robospice-cache-parent/robospice-cache/src/main/java/com/octo/android/robospice/persistence/binary/InFileInputStreamObjectPersister.java
@@ -36,7 +36,7 @@ public class InFileInputStreamObjectPersister extends InFileObjectPersister<Inpu
             // Should not occur (we test before if
             // file exists)
             // Do not throw, file is not cached
-            Ln.w("file " + file.getAbsolutePath() + " does not exists", e);
+            Ln.w(e, "file %s does not exists", file.getAbsolutePath());
             return null;
         }
     }
@@ -60,7 +60,7 @@ public class InFileInputStreamObjectPersister extends InFileObjectPersister<Inpu
                         try {
                             FileUtils.writeByteArrayToFile(getCacheFile(cacheKey), byteArray);
                         } catch (IOException e) {
-                            Ln.e(e, "An error occured on saving request " + cacheKey + " data asynchronously");
+                            Ln.e(e, "An error occured on saving request %s data asynchronously", cacheKey);
                         }
                     };
                 };

--- a/robospice-cache-parent/robospice-cache/src/main/java/com/octo/android/robospice/persistence/string/InFileStringObjectPersister.java
+++ b/robospice-cache-parent/robospice-cache/src/main/java/com/octo/android/robospice/persistence/string/InFileStringObjectPersister.java
@@ -34,7 +34,7 @@ public class InFileStringObjectPersister extends InFileObjectPersister<String> {
             // Should not occur (we test before if
             // file exists)
             // Do not throw, file is not cached
-            Ln.w("file " + file.getAbsolutePath() + " does not exists", e);
+            Ln.w(e, "file %s does not exists", file.getAbsolutePath());
             return null;
         } catch (Exception e) {
             throw new CacheLoadingException(e);
@@ -43,7 +43,7 @@ public class InFileStringObjectPersister extends InFileObjectPersister<String> {
 
     @Override
     public String saveDataToCacheAndReturnData(final String data, final Object cacheKey) throws CacheSavingException {
-        Ln.v("Saving String " + data + " into cacheKey = " + cacheKey);
+        Ln.v("Saving String %s into cacheKey = %s", data, cacheKey);
         try {
             if (isAsyncSaveEnabled()) {
 
@@ -53,7 +53,7 @@ public class InFileStringObjectPersister extends InFileObjectPersister<String> {
                         try {
                             FileUtils.writeStringToFile(getCacheFile(cacheKey), data, CharEncoding.UTF_8);
                         } catch (IOException e) {
-                            Ln.e(e, "An error occured on saving request " + cacheKey + " data asynchronously");
+                            Ln.e(e, "An error occured on saving request %s data asynchronously", cacheKey);
                         }
                     };
                 };

--- a/robospice-core-parent/robospice-core-test/src/main/java/com/octo/android/robospice/stub/DoubleInMemoryPersisterStub.java
+++ b/robospice-core-parent/robospice-core-test/src/main/java/com/octo/android/robospice/stub/DoubleInMemoryPersisterStub.java
@@ -32,7 +32,7 @@ public class DoubleInMemoryPersisterStub extends ObjectPersister<Double> {
         if (maxTimeInCache == DurationInMillis.ALWAYS_EXPIRED || maxTimeInCache > DurationInMillis.ONE_MINUTE) {
             return null;
         }
-        Ln.d("Value in cache for " + cacheKey + " is " + map.get(cacheKey));
+        Ln.d("Value in cache for %s is %s", cacheKey, map.get(cacheKey));
         return map.get(cacheKey);
     }
 
@@ -49,7 +49,7 @@ public class DoubleInMemoryPersisterStub extends ObjectPersister<Double> {
 
     @Override
     public Double saveDataToCacheAndReturnData(Double data, Object cacheKey) throws CacheSavingException {
-        Ln.d("Adding " + data + " to cache at " + cacheKey);
+        Ln.d("Adding %s to cache at %s", data, cacheKey);
         map.put(cacheKey, data);
         return data;
     }

--- a/robospice-core-parent/robospice-core-test/src/main/java/com/octo/android/robospice/stub/DoubleInMemoryPersisterStub.java
+++ b/robospice-core-parent/robospice-core-test/src/main/java/com/octo/android/robospice/stub/DoubleInMemoryPersisterStub.java
@@ -56,7 +56,7 @@ public class DoubleInMemoryPersisterStub extends ObjectPersister<Double> {
 
     @Override
     public boolean removeDataFromCache(Object cacheKey) {
-        Ln.d("Clearing cache at" + cacheKey);
+        Ln.d("Clearing cache at %s", cacheKey);
         map.remove(cacheKey);
         return true;
     }

--- a/robospice-core-parent/robospice/src/main/java/com/octo/android/robospice/SpiceManager.java
+++ b/robospice-core-parent/robospice/src/main/java/com/octo/android/robospice/SpiceManager.java
@@ -279,11 +279,11 @@ public class SpiceManager implements Runnable {
         try {
             if (spiceRequest != null && spiceService != null) {
                 if (isStopped) {
-                    Ln.d("Sending request to service without listeners : " + spiceRequest.getClass().getSimpleName());
+                    Ln.d("Sending request to service without listeners : %s", spiceRequest.getClass().getSimpleName());
                     spiceService.addRequest(spiceRequest, null);
                 } else {
                     final Set<RequestListener<?>> listRequestListener = mapRequestToLaunchToRequestListener.get(spiceRequest);
-                    Ln.d("Sending request to service : " + spiceRequest.getClass().getSimpleName());
+                    Ln.d("Sending request to service : %s", spiceRequest.getClass().getSimpleName());
                     spiceService.addRequest(spiceRequest, listRequestListener);
                 }
             } else {
@@ -757,7 +757,7 @@ public class SpiceManager implements Runnable {
                     for (final CachedSpiceRequest<?> cachedSpiceRequest : mapRequestToLaunchToRequestListener.keySet()) {
                         final Set<RequestListener<?>> setRequestListeners = mapRequestToLaunchToRequestListener.get(cachedSpiceRequest);
                         if (setRequestListeners != null) {
-                            Ln.d("Removing listeners of request to launch : " + cachedSpiceRequest.toString() + " : " + setRequestListeners.size());
+                            Ln.d("Removing listeners of request to launch : %s : %s", cachedSpiceRequest.toString(), setRequestListeners.size());
                             spiceService.dontNotifyRequestListenersForRequest(cachedSpiceRequest, setRequestListeners);
                         }
                     }
@@ -786,7 +786,7 @@ public class SpiceManager implements Runnable {
 
                     final Set<RequestListener<?>> setRequestListeners = mapPendingRequestToRequestListener.get(cachedSpiceRequest);
                     if (setRequestListeners != null) {
-                        Ln.d("Removing listeners of pending request : " + cachedSpiceRequest.toString() + " : " + setRequestListeners.size());
+                        Ln.d("Removing listeners of pending request : %s : %s", cachedSpiceRequest.toString(), setRequestListeners.size());
                         spiceService.dontNotifyRequestListenersForRequest(cachedSpiceRequest, setRequestListeners);
                     }
                 }
@@ -1085,7 +1085,7 @@ public class SpiceManager implements Runnable {
                 if (service instanceof SpiceServiceBinder) {
                     spiceService = ((SpiceServiceBinder) service).getSpiceService();
                     spiceService.addSpiceServiceListener(removerSpiceServiceListener);
-                    Ln.d("Bound to service : " + spiceService.getClass().getSimpleName());
+                    Ln.d("Bound to service : %s", spiceService.getClass().getSimpleName());
                     conditionServiceBound.signalAll();
                 } else {
                     Ln.e("Unexpected IBinder service at onServiceConnected :%s ", service.getClass().getName());
@@ -1101,7 +1101,7 @@ public class SpiceManager implements Runnable {
             lockAcquireService.lock();
             try {
                 if (spiceService != null) {
-                    Ln.d("Unbound from service start : " + spiceService.getClass().getSimpleName());
+                    Ln.d("Unbound from service start : %s", spiceService.getClass().getSimpleName());
                     spiceService = null;
                     isUnbinding = false;
                     conditionServiceUnbound.signalAll();
@@ -1200,8 +1200,8 @@ public class SpiceManager implements Runnable {
         } catch (Exception t) {
             // this should not happen in apps, but can happen during tests.
             Ln.d(t, "Binding to service failed.");
-            Ln.d("Context is" + context);
-            Ln.d("ApplicationContext is " + context.getApplicationContext());
+            Ln.d("Context is %s", context);
+            Ln.d("ApplicationContext is %s", context.getApplicationContext());
         } finally {
             lockSendRequestsToService.unlock();
             lockAcquireService.unlock();
@@ -1224,7 +1224,7 @@ public class SpiceManager implements Runnable {
                 spiceService.removeSpiceServiceListener(removerSpiceServiceListener);
                 Ln.v("Unbinding from service.");
                 context.getApplicationContext().unbindService(this.spiceServiceConnection);
-                Ln.d("Unbound from service : " + spiceService.getClass().getSimpleName());
+                Ln.d("Unbound from service : %s", spiceService.getClass().getSimpleName());
                 spiceService = null;
                 isUnbinding = false;
             }

--- a/robospice-core-parent/robospice/src/main/java/com/octo/android/robospice/SpiceManager.java
+++ b/robospice-core-parent/robospice/src/main/java/com/octo/android/robospice/SpiceManager.java
@@ -663,7 +663,7 @@ public class SpiceManager implements Runnable {
         try {
 
             final boolean requestNotPassedToServiceYet = removeListenersOfCachedRequestToLaunch(request);
-            Ln.v("Removed from requests to launch list : " + requestNotPassedToServiceYet);
+            Ln.v("Removed from requests to launch list : %s", requestNotPassedToServiceYet);
 
             // if the request was already passed to service, bind to
             // service and

--- a/robospice-core-parent/robospice/src/main/java/com/octo/android/robospice/SpiceService.java
+++ b/robospice-core-parent/robospice/src/main/java/com/octo/android/robospice/SpiceService.java
@@ -480,7 +480,7 @@ public abstract class SpiceService extends Service {
     }
 
     public void dumpState() {
-        Ln.v(requestProcessor.toString());
+        Ln.v(requestProcessor);
     }
 
     public void addSpiceServiceListener(final SpiceServiceListener spiceServiceListener) {
@@ -492,7 +492,7 @@ public abstract class SpiceService extends Service {
     }
 
     private void stopIfNotBoundAndHasNoPendingRequests() {
-        Ln.v("Pending requests : " + currentPendingRequestCount);
+        Ln.v("Pending requests : %s", currentPendingRequestCount);
         if (currentPendingRequestCount == 0 && !isBound) {
             stopSelf();
         }
@@ -503,7 +503,7 @@ public abstract class SpiceService extends Service {
         if (notification == null || isJUnit) {
             return;
         }
-        Ln.v("Pending requests : " + currentPendingRequestCount);
+        Ln.v("Pending requests : %s", currentPendingRequestCount);
         if (isBound || currentPendingRequestCount == 0) {
             Ln.v("Stop foreground");
             stopForeground(true);

--- a/robospice-core-parent/robospice/src/main/java/com/octo/android/robospice/notification/SpiceServiceListenerNotificationService.java
+++ b/robospice-core-parent/robospice/src/main/java/com/octo/android/robospice/notification/SpiceServiceListenerNotificationService.java
@@ -78,7 +78,7 @@ public abstract class SpiceServiceListenerNotificationService extends Service {
         if (foreground) {
             startForeground(notificationId, onCreateForegroundNotification());
         }
-        Ln.d(getClass().getSimpleName() + " started.");
+        Ln.d("%s started.", getClass().getSimpleName());
     }
 
     @Override

--- a/robospice-core-parent/robospice/src/main/java/com/octo/android/robospice/request/DefaultRequestRunner.java
+++ b/robospice-core-parent/robospice/src/main/java/com/octo/android/robospice/request/DefaultRequestRunner.java
@@ -69,7 +69,7 @@ public class DefaultRequestRunner implements RequestRunner {
 
         try {
             if (isStopped) {
-                Ln.d("Dropping request : " + request + " as runner is stopped.");
+                Ln.d("Dropping request : %s as runner is stopped.", request);
                 return;
             }
             planRequestExecution(request);
@@ -80,7 +80,7 @@ public class DefaultRequestRunner implements RequestRunner {
 
     protected <T> void processRequest(final CachedSpiceRequest<T> request) {
         final long startTime = System.currentTimeMillis();
-        Ln.d("Processing request : " + request);
+        Ln.d("Processing request : %s", request);
 
         T result = null;
 
@@ -94,13 +94,13 @@ public class DefaultRequestRunner implements RequestRunner {
         if (request.getRequestCacheKey() != null && request.getCacheDuration() != DurationInMillis.ALWAYS_EXPIRED) {
             // First, search data in cache
             try {
-                Ln.d("Loading request from cache : " + request);
+                Ln.d("Loading request from cache : %s", request);
                 request.setStatus(RequestStatus.READING_FROM_CACHE);
                 result = loadDataFromCache(request.getResultType(), request.getRequestCacheKey(), request.getCacheDuration());
                 // if something is found in cache, fire result and finish
                 // request
                 if (result != null) {
-                    Ln.d("Request loaded from cache : " + request + " result=" + result);
+                    Ln.d("Request loaded from cache : %s result=%s", request, result);
                     requestProgressManager.notifyListenersOfRequestSuccess(request, result);
                     printRequestProcessingDuration(startTime, request);
                     return;

--- a/robospice-core-parent/robospice/src/main/java/com/octo/android/robospice/request/DefaultRequestRunner.java
+++ b/robospice-core-parent/robospice/src/main/java/com/octo/android/robospice/request/DefaultRequestRunner.java
@@ -151,7 +151,7 @@ public class DefaultRequestRunner implements RequestRunner {
             Ln.d("Network request call ended.");
         } catch (final Exception e) {
             if (!request.isCancelled()) {
-                Ln.e(e, "An exception occurred during request network execution :" + e.getMessage());
+                Ln.e(e, "An exception occurred during request network execution : %s", e.getMessage());
                 handleRetry(request, new NetworkException("Exception occurred during invocation of web service.", e));
             } else {
                 Ln.e("An exception occurred during request network execution but request was cancelled, so listeners are not called.");
@@ -277,7 +277,7 @@ public class DefaultRequestRunner implements RequestRunner {
                             Thread.sleep(request.getRetryPolicy().getDelayBeforeRetry());
                             executeRequest(request);
                         } catch (InterruptedException e) {
-                            Ln.e(e, "Retry attempt failed for request " + request);
+                            Ln.e(e, "Retry attempt failed for request %s", request);
                         }
                     }
                 }).start();

--- a/robospice-core-parent/robospice/src/main/java/com/octo/android/robospice/request/RequestProcessor.java
+++ b/robospice-core-parent/robospice/src/main/java/com/octo/android/robospice/request/RequestProcessor.java
@@ -56,11 +56,11 @@ public class RequestProcessor {
     // ============================================================================================
     public void addRequest(final CachedSpiceRequest<?> request, final Set<RequestListener<?>> listRequestListener) {
         if (isStopped) {
-            Ln.d("Dropping request : " + request + " as processor is stopped.");
+            Ln.d("Dropping request : %s as processor is stopped.", request);
             return;
         }
 
-        Ln.d("Adding request to queue " + hashCode() + ": " + request + " size is " + mapRequestToRequestListener.size());
+        Ln.d("Adding request to queue %s: %s size is %s", hashCode(), request, mapRequestToRequestListener.size());
 
         if (request.isCancelled()) {
             synchronized (mapRequestToRequestListener) {

--- a/robospice-core-parent/robospice/src/main/java/com/octo/android/robospice/request/RequestProgressManager.java
+++ b/robospice-core-parent/robospice/src/main/java/com/octo/android/robospice/request/RequestProgressManager.java
@@ -119,7 +119,7 @@ public class RequestProgressManager {
     }
 
     public void notifyListenersOfRequestCancellation(final CachedSpiceRequest<?> request) {
-        Ln.d("Not calling network request : %s as it is cancelled. ", request);
+        Ln.d("Not calling network request : %s as it is cancelled.", request);
         final Set<RequestListener<?>> listeners = mapRequestToRequestListener.get(request);
         notifyListenersOfRequestProgress(request, listeners, RequestStatus.COMPLETE);
 

--- a/robospice-core-parent/robospice/src/main/java/com/octo/android/robospice/request/RequestProgressManager.java
+++ b/robospice-core-parent/robospice/src/main/java/com/octo/android/robospice/request/RequestProgressManager.java
@@ -119,7 +119,7 @@ public class RequestProgressManager {
     }
 
     public void notifyListenersOfRequestCancellation(final CachedSpiceRequest<?> request) {
-        Ln.d("Not calling network request : " + request + " as it is cancelled. ");
+        Ln.d("Not calling network request : %s as it is cancelled. ", request);
         final Set<RequestListener<?>> listeners = mapRequestToRequestListener.get(request);
         notifyListenersOfRequestProgress(request, listeners, RequestStatus.COMPLETE);
 
@@ -144,7 +144,7 @@ public class RequestProgressManager {
         requestListenerNotifier.clearNotificationsForRequest(request, setRequestListener);
 
         if (setRequestListener != null && listRequestListener != null) {
-            Ln.d("Removing listeners of request : " + request.toString() + " : " + setRequestListener.size());
+            Ln.d("Removing listeners of request : %s : %s", request.toString(), setRequestListener.size());
             setRequestListener.removeAll(listRequestListener);
         }
     }

--- a/robospice-core-parent/robospice/src/main/java/com/octo/android/robospice/request/notifier/DefaultRequestListenerNotifier.java
+++ b/robospice-core-parent/robospice/src/main/java/com/octo/android/robospice/request/notifier/DefaultRequestListenerNotifier.java
@@ -100,7 +100,7 @@ public class DefaultRequestListenerNotifier implements RequestListenerNotifier {
                 return;
             }
 
-            Ln.v("Notifying " + listeners.size() + " listeners of request not found");
+            Ln.v("Notifying %s listeners of request not found", listeners.size());
             synchronized (listeners) {
                 for (final RequestListener<?> listener : listeners) {
                     if (listener != null && listener instanceof PendingRequestListener) {
@@ -128,7 +128,7 @@ public class DefaultRequestListenerNotifier implements RequestListenerNotifier {
                 return;
             }
 
-            Ln.v("Notifying " + listeners.size() + " listeners of progress " + progress);
+            Ln.v("Notifying %s listeners of progress %s", listeners.size(), progress);
             synchronized (listeners) {
                 for (final RequestListener<?> listener : listeners) {
                     if (listener != null && listener instanceof RequestProgressListener) {
@@ -163,7 +163,7 @@ public class DefaultRequestListenerNotifier implements RequestListenerNotifier {
             }
 
             final String resultMsg = spiceException == null ? "success" : "failure";
-            Ln.v("Notifying " + listeners.size() + " listeners of request " + resultMsg);
+            Ln.v("Notifying %s listeners of request %s", listeners.size(), resultMsg);
             synchronized (listeners) {
                 for (final RequestListener<?> listener : listeners) {
                     if (listener != null) {

--- a/robospice-core-parent/robospice/src/main/java/com/octo/android/robospice/request/notifier/SpiceServiceListenerNotifier.java
+++ b/robospice-core-parent/robospice/src/main/java/com/octo/android/robospice/request/notifier/SpiceServiceListenerNotifier.java
@@ -143,7 +143,7 @@ public class SpiceServiceListenerNotifier {
      * @param runnable a runnable to be posted immediatly on the queue.
      */
     protected void post(Runnable runnable) {
-        Ln.d("Message queue is " + messageQueue);
+        Ln.d("Message queue is %s", messageQueue);
 
         if (messageQueue == null) {
             return;

--- a/robospice-core-parent/robospice/src/main/java/com/octo/android/robospice/request/simple/SimpleTextRequest.java
+++ b/robospice-core-parent/robospice/src/main/java/com/octo/android/robospice/request/simple/SimpleTextRequest.java
@@ -26,7 +26,7 @@ public class SimpleTextRequest extends SpiceRequest<String> {
     @Override
     public String loadDataFromNetwork() throws Exception {
         try {
-            Ln.d("Call web service " + url);
+            Ln.d("Call web service %s", url);
             return IOUtils.toString(new InputStreamReader(new URL(url).openStream(), CharEncoding.UTF_8));
         } catch (final MalformedURLException e) {
             Ln.e(e, "Unable to create URL");


### PR DESCRIPTION
Hello!
This pull request is fix of #403 
When toString methods of some objects are expensive, we should be able to disable calling them in logging by changing log level. But when we use string concatenation, they will be called independently of log level. So let's use formatted version of logging. I have changed all logging calls that I have found.
Fox example, it is very actual for protobuf classes, because toString methods of them are overrided to write down all fields.