### PR TITLE
Sync fixes

### DIFF
--- a/robospice-core-parent/robospice/src/main/java/com/octo/android/robospice/request/RequestProcessor.java
+++ b/robospice-core-parent/robospice/src/main/java/com/octo/android/robospice/request/RequestProcessor.java
@@ -77,23 +77,25 @@ public class RequestProcessor {
         boolean aggregated = false;
         Set<RequestListener<?>> listRequestListenerForThisRequest;
 
-        synchronized (mapRequestToRequestListener) {
-            listRequestListenerForThisRequest = mapRequestToRequestListener.get(request);
+        synchronized (requestProgressManager) {
+            synchronized (mapRequestToRequestListener) {
+                listRequestListenerForThisRequest = mapRequestToRequestListener.get(request);
 
-            if (listRequestListenerForThisRequest == null) {
-                if (request.isProcessable()) {
-                    Ln.d("Adding entry for type %s and cacheKey %s.", request.getResultType(), request.getRequestCacheKey());
-                    listRequestListenerForThisRequest = Collections.synchronizedSet(new HashSet<RequestListener<?>>());
-                    this.mapRequestToRequestListener.put(request, listRequestListenerForThisRequest);
+                if (listRequestListenerForThisRequest == null) {
+                    if (request.isProcessable()) {
+                        Ln.d("Adding entry for type %s and cacheKey %s.", request.getResultType(), request.getRequestCacheKey());
+                        listRequestListenerForThisRequest = Collections.synchronizedSet(new HashSet<RequestListener<?>>());
+                        this.mapRequestToRequestListener.put(request, listRequestListenerForThisRequest);
+                    }
+                } else {
+                    Ln.d("Request for type %s and cacheKey %s already exists.", request.getResultType(), request.getRequestCacheKey());
+                    aggregated = true;
                 }
-            } else {
-                Ln.d("Request for type %s and cacheKey %s already exists.", request.getResultType(), request.getRequestCacheKey());
-                aggregated = true;
             }
-        }
 
-        if (listRequestListener != null && listRequestListenerForThisRequest != null) {
-            listRequestListenerForThisRequest.addAll(listRequestListener);
+            if (listRequestListener != null && listRequestListenerForThisRequest != null) {
+                listRequestListenerForThisRequest.addAll(listRequestListener);
+            }
         }
 
         if (aggregated) {

--- a/robospice-core-parent/robospice/src/main/java/com/octo/android/robospice/request/RequestProgressManager.java
+++ b/robospice-core-parent/robospice/src/main/java/com/octo/android/robospice/request/RequestProgressManager.java
@@ -100,7 +100,7 @@ public class RequestProgressManager {
         requestListenerNotifier.notifyListenersOfRequestSuccess(request, result, listeners);
     }
 
-    public <T> void notifyListenersOfRequestSuccess(final CachedSpiceRequest<T> request, final T result) {
+    public synchronized  <T> void notifyListenersOfRequestSuccess(final CachedSpiceRequest<T> request, final T result) {
         final Set<RequestListener<?>> listeners = mapRequestToRequestListener.get(request);
         notifyListenersOfRequestProgress(request, listeners, RequestStatus.COMPLETE);
 
@@ -109,7 +109,7 @@ public class RequestProgressManager {
         notifyOfRequestProcessed(request, listeners);
     }
 
-    public <T> void notifyListenersOfRequestFailure(final CachedSpiceRequest<T> request, final SpiceException e) {
+    public synchronized <T> void notifyListenersOfRequestFailure(final CachedSpiceRequest<T> request, final SpiceException e) {
         final Set<RequestListener<?>> listeners = mapRequestToRequestListener.get(request);
         notifyListenersOfRequestProgress(request, listeners, RequestStatus.COMPLETE);
 
@@ -118,7 +118,7 @@ public class RequestProgressManager {
         notifyOfRequestProcessed(request, listeners);
     }
 
-    public void notifyListenersOfRequestCancellation(final CachedSpiceRequest<?> request) {
+    public synchronized void notifyListenersOfRequestCancellation(final CachedSpiceRequest<?> request) {
         Ln.d("Not calling network request : " + request + " as it is cancelled. ");
         final Set<RequestListener<?>> listeners = mapRequestToRequestListener.get(request);
         notifyListenersOfRequestProgress(request, listeners, RequestStatus.COMPLETE);


### PR DESCRIPTION
This pull request fixes rare case of ignoring listener of aggregated requests. Please check if my synchronization variant is right and doesn't break anything, but in my project it works.
Problem: if you execute two same requests in very close time, for example from different threads, they are aggregated. But it can happen that listeners were taken from map, then sent to request notifier by progress manager. And before removing from map request processor will take listeners set from map and add listener to it. So that listener will never be called because notification was executed alreafy.