### PR TITLE
Update 'android-maven-plugin' plugin and few others

### DIFF
--- a/extensions/robospice-google-http-client-parent/robospice-google-http-client-test/pom.xml
+++ b/extensions/robospice-google-http-client-parent/robospice-google-http-client-test/pom.xml
@@ -60,7 +60,7 @@
 	<build>
 		<plugins>
 			<plugin>
-				<groupId>com.jayway.maven.plugins.android.generation2</groupId>
+				<groupId>com.simpligility.maven.plugins</groupId>
 				<artifactId>android-maven-plugin</artifactId>
 			</plugin>
 			<plugin>

--- a/extensions/robospice-okhttp-parent/robospice-okhttp-test/pom.xml
+++ b/extensions/robospice-okhttp-parent/robospice-okhttp-test/pom.xml
@@ -56,7 +56,7 @@
 	<build>
 		<plugins>
 			<plugin>
-				<groupId>com.jayway.maven.plugins.android.generation2</groupId>
+				<groupId>com.simpligility.maven.plugins</groupId>
 				<artifactId>android-maven-plugin</artifactId>
 			</plugin>
 			<plugin>

--- a/extensions/robospice-ormlite-parent/robospice-ormlite-test/pom.xml
+++ b/extensions/robospice-ormlite-parent/robospice-ormlite-test/pom.xml
@@ -43,7 +43,7 @@
 	<build>
 		<plugins>
 			<plugin>
-				<groupId>com.jayway.maven.plugins.android.generation2</groupId>
+				<groupId>com.simpligility.maven.plugins</groupId>
 				<artifactId>android-maven-plugin</artifactId>
 			</plugin>
 			<plugin>

--- a/extensions/robospice-retrofit-parent/robospice-retrofit-test/pom.xml
+++ b/extensions/robospice-retrofit-parent/robospice-retrofit-test/pom.xml
@@ -65,7 +65,7 @@
 	<build>
 		<plugins>
 			<plugin>
-				<groupId>com.jayway.maven.plugins.android.generation2</groupId>
+				<groupId>com.simpligility.maven.plugins</groupId>
 				<artifactId>android-maven-plugin</artifactId>
 			</plugin>
 			<plugin>

--- a/extensions/robospice-spring-android-parent/robospice-spring-android-test/pom.xml
+++ b/extensions/robospice-spring-android-parent/robospice-spring-android-test/pom.xml
@@ -63,7 +63,7 @@
 	<build>
 		<plugins>
 			<plugin>
-				<groupId>com.jayway.maven.plugins.android.generation2</groupId>
+				<groupId>com.simpligility.maven.plugins</groupId>
 				<artifactId>android-maven-plugin</artifactId>
 			</plugin>
 			<plugin>

--- a/extensions/robospice-ui-spicelist-parent/robospice-ui-spicelist-test/pom.xml
+++ b/extensions/robospice-ui-spicelist-parent/robospice-ui-spicelist-test/pom.xml
@@ -42,7 +42,7 @@
 	<build>
 		<plugins>
 			<plugin>
-				<groupId>com.jayway.maven.plugins.android.generation2</groupId>
+				<groupId>com.simpligility.maven.plugins</groupId>
 				<artifactId>android-maven-plugin</artifactId>
 			</plugin>
 			<plugin>

--- a/findbugs-exclude.xml
+++ b/findbugs-exclude.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<FindBugsFilter>
+	<Match>
+		<Bug pattern="WMI_WRONG_MAP_ITERATOR" />
+		<Class name="com.octo.android.robospice.SpiceManager" />
+		<Or>
+			<Method name="removeListenersOfCachedRequestToLaunch" />
+			<Method name="removeListenersOfPendingCachedRequest" />
+			<Method name="dontNotifyAnyRequestListenersInternal" />
+			<Method name="removeListenersOfAllPendingCachedRequests" />
+		</Or>
+	</Match>
+</FindBugsFilter>

--- a/pom.xml
+++ b/pom.xml
@@ -103,13 +103,13 @@
 		<android-platform.version>19</android-platform.version>
 		<android-annotations.version>4.1.1.4</android-annotations.version>
 		<easymock.version>3.2</easymock.version>
-		<dexmaker.version>1.1</dexmaker.version>
+		<dexmaker.version>1.2</dexmaker.version>
 		<mockwebserver.version>20130706</mockwebserver.version>
 		<junit.version>4.11</junit.version>
 		<commons-logging.version>1.2</commons-logging.version>
 
 		<!-- PLUGINS VERSIONS -->
-		<android-maven-plugin.version>3.8.2</android-maven-plugin.version>
+		<android-maven-plugin.version>4.4.1</android-maven-plugin.version>
 		<site-maven-plugin.version>0.9</site-maven-plugin.version>
 		<maven-project-info-reports-plugin.version>2.7</maven-project-info-reports-plugin.version>
 		<maven-surefire-report-plugin.version>2.15</maven-surefire-report-plugin.version>
@@ -117,14 +117,14 @@
 		<maven-source-plugin.version>2.2.1</maven-source-plugin.version>
 		<maven-deploy-plugin.version>2.7</maven-deploy-plugin.version>
 		<maven-release-plugin.version>2.5</maven-release-plugin.version>
-		<maven-javadoc-plugin.version>2.9</maven-javadoc-plugin.version>
+		<maven-javadoc-plugin.version>2.10.3</maven-javadoc-plugin.version>
 		<maven-jxr-plugin.version>2.3</maven-jxr-plugin.version>
-		<maven-compiler-plugin.version>3.1</maven-compiler-plugin.version>
-                <maven-dependency-plugin.version>2.8</maven-dependency-plugin.version>
+		<maven-compiler-plugin.version>3.5.1</maven-compiler-plugin.version>
+		<maven-dependency-plugin.version>2.8</maven-dependency-plugin.version>
 		<maven-site-plugin.version>3.3</maven-site-plugin.version>
 		<doxia-module-markdown.version>1.3</doxia-module-markdown.version>
 		<maven-pmd-plugin.version>3.0.1</maven-pmd-plugin.version>
-		<findbugs-maven-plugin.version>2.5.3</findbugs-maven-plugin.version>
+		<findbugs-maven-plugin.version>3.0.3</findbugs-maven-plugin.version>
 		<maven-checkstyle-plugin.version>2.11</maven-checkstyle-plugin.version>
 		<eclipse-lifecycle-plugin.version>1.0.0</eclipse-lifecycle-plugin.version>
 
@@ -249,7 +249,7 @@
 				</plugin>
 				<!-- Android config -->
 				<plugin>
-					<groupId>com.jayway.maven.plugins.android.generation2</groupId>
+					<groupId>com.simpligility.maven.plugins</groupId>
 					<artifactId>android-maven-plugin</artifactId>
 					<version>${android-maven-plugin.version}</version>
 					<configuration>
@@ -286,6 +286,10 @@
 							<goals>
 								<goal>jar</goal>
 							</goals>
+							<configuration>
+                                <!-- Disable a new Java 8 DocLint feature so far -->
+								<additionalparam>-Xdoclint:none</additionalparam>
+							</configuration>
 						</execution>
 						<execution>
 							<id>aggregate</id>
@@ -343,6 +347,9 @@
 					<groupId>org.codehaus.mojo</groupId>
 					<artifactId>findbugs-maven-plugin</artifactId>
 					<version>${findbugs-maven-plugin.version}</version>
+					<configuration>
+						<excludeFilterFile>findbugs-exclude.xml</excludeFilterFile>
+					</configuration>
 					<executions>
 						<execution>
 							<id>findbugs-check</id>

--- a/robospice-cache-parent/robospice-cache-test/pom.xml
+++ b/robospice-cache-parent/robospice-cache-test/pom.xml
@@ -38,7 +38,7 @@
 	<build>
 		<plugins>
 			<plugin>
-				<groupId>com.jayway.maven.plugins.android.generation2</groupId>
+				<groupId>com.simpligility.maven.plugins</groupId>
 				<artifactId>android-maven-plugin</artifactId>
 			</plugin>
 			<plugin>

--- a/robospice-cache-parent/robospice-cache/src/main/java/com/octo/android/robospice/persistence/file/InFileObjectPersister.java
+++ b/robospice-cache-parent/robospice-cache/src/main/java/com/octo/android/robospice/persistence/file/InFileObjectPersister.java
@@ -138,21 +138,31 @@ public abstract class InFileObjectPersister<T> extends ObjectPersister<T> {
 
     @Override
     public void removeAllDataFromCache() {
-        File cacheFolder = getCacheFolder();
-        File[] cacheFileList = cacheFolder.listFiles(new FileFilter() {
+        File folder = getCacheFolder();
+        if (folder == null) {
+            Ln.d("Skip 'removeAllDataFromCache' operation. Cache folder is 'null', so there's"
+                    + " nothing to remove.");
+            return;
+        }
+        File[] cacheFileList = folder.listFiles(new FileFilter() {
 
             @Override
             public boolean accept(File file) {
                 return file.getName().startsWith(getCachePrefix());
             }
         });
-
-        boolean allDeleted = true;
-        for (File cacheFile : cacheFileList) {
-            allDeleted = cacheFile.delete() && allDeleted;
+        if (cacheFileList == null) {
+            Ln.d("Cache is already clear.");
+            return;
         }
-        if (allDeleted || cacheFileList.length == 0) {
-            Ln.d("Some file could not be deleted from cache.");
+        for (File cacheFile : cacheFileList) {
+            // Calm down the 'find-bugs-plugin' which complains about a possible NPE here
+            if (cacheFile == null) {
+                continue;
+            }
+            if (!cacheFile.delete()) {
+                Ln.d("File '" + cacheFile.getName() + "' could not be deleted from cache.");
+            }
         }
     }
 

--- a/robospice-core-parent/robospice-core-test/pom.xml
+++ b/robospice-core-parent/robospice-core-test/pom.xml
@@ -50,7 +50,7 @@
 	<build>
 		<plugins>
 			<plugin>
-				<groupId>com.jayway.maven.plugins.android.generation2</groupId>
+				<groupId>com.simpligility.maven.plugins</groupId>
 				<artifactId>android-maven-plugin</artifactId>
 			</plugin>
 			<plugin>


### PR DESCRIPTION
RS wasn't building with Java 8, and it soon became annoying to set JAVA_HOME to Java 7 every time. I've looked into it and found out about a new Java 8 feature called DocLint which blames our JavaDoc comments of being incomplete. So i switched this feature off so far: `-Xdoclint:none` in a  [second commit (db98ee8)](https://github.com/stephanenicolas/robospice/commit/eb0c6399d2c5005f913647d860fbc2a5edd506d4). Also this commit updates 'android-maven-plugin' in whole RS project and a few more maven plugins.

// ------------------------------------------------------------------
About the  [first one (db98ee8)](https://github.com/stephanenicolas/robospice/commit/db98ee80069b8077a9c76bcbd4305c6c9a5654ab). There was this message printed everywhere in the log:

> "Some file could not be deleted from cache."

As for me this massage does not say anything useful at all. And the second thing is the message is printed even when there's nothing in a cache, because of this piece of code: 
`if (allDeleted || cacheFileList.length == 0) {`
`Ln.d("Some file could not be deleted from cache.");`
`}`
Here in case there are no files in the cache this message just keeps being printed.
It is fixed in the first commit.
Take a look if it is useful to you.
